### PR TITLE
Add missing semicolons after class properties

### DIFF
--- a/src/components/AuthenticatedRoute.js
+++ b/src/components/AuthenticatedRoute.js
@@ -18,5 +18,5 @@ export default class AuthenticatedRoute extends Route {
         callback();
       });
     }
-  }
+  };
 }

--- a/src/components/LoginForm.js
+++ b/src/components/LoginForm.js
@@ -12,7 +12,7 @@ export default class LoginForm extends React.Component {
     password: '',
     isProcessing: false,
     errorMessage: null
-  }
+  };
 
   onFormSubmit(e) {
     e.preventDefault();

--- a/src/components/LogoutRoute.js
+++ b/src/components/LogoutRoute.js
@@ -17,5 +17,5 @@ export default class LogoutRoute extends Route {
         callback();
       });
     }
-  }
+  };
 }

--- a/src/components/RegistrationForm.js
+++ b/src/components/RegistrationForm.js
@@ -18,7 +18,7 @@ export default class RegistrationForm extends React.Component {
     isAccountCreated: false,
     isAccountEnabled: false,
     errorMessage: null
-  }
+  };
 
   onFormSubmit(e) {
     e.preventDefault();

--- a/src/components/VerifyEmailView.js
+++ b/src/components/VerifyEmailView.js
@@ -6,7 +6,7 @@ import UserActions from '../actions/UserActions';
 export default class VerifyEmailView extends React.Component {
   state = {
     status: 'VERIFYING'
-  }
+  };
 
   constructor() {
     super(...arguments);


### PR DESCRIPTION
This PR adds missing semicolons after class properties.

``` bash
SyntaxError: src/components/AuthenticatedRoute.js: A semicolon is required after a class property (21:3)
  19 |       });
  20 |     }
> 21 |   }
     |    ^
  22 | }
  23 |
```
### How to verify
1. Checkout this branch
2. Install Node version `v4.2.4`
3. Run a clean `npm install`
4. Run `npm run build`
5. Verify that you doesn't get any syntax errors, like the one above
