### PR TITLE
Feature: Custom reset password form

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -179,18 +179,18 @@ Customize the form by providing your own markup.
 
 ```html
 <ResetPasswordForm>
-  <div showWhen="form.sent">
+  <div spIf="form.sent">
     <p>We have sent a password reset link to the email address of the account that you specified.<br />
     Please check your email for this message, then click on the link.</p>
   </div>
-  <div showWhen="!form.sent">
+  <div spIf="!form.sent">
     <p>
       <label htmlFor="email">Email</label><br />
       <input id="email" type="text" name="email" />
     </p>
-    <p showWhen="form.error">
+    <p spIf="form.error">
       <strong>Error:</strong><br />
-      <span replaceWith="form.errorMessage" />
+      <span spBind="form.errorMessage" />
     </p>
     <p>
       <input type="submit" value="Request Password reset" />

--- a/docs/api.md
+++ b/docs/api.md
@@ -175,6 +175,55 @@ Renders a password reset form.
 <ResetPasswordForm />
 ```
 
+Customize the form by providing your own markup.
+
+```html
+<ResetPasswordForm>
+  <div showWhen="form.sent">
+    <p>We have sent a password reset link to the email address of the account that you specified.<br />
+    Please check your email for this message, then click on the link.</p>
+  </div>
+  <div showWhen="!form.sent">
+    <p>
+      <label htmlFor="email">Email</label><br />
+      <input id="email" type="text" name="email" />
+    </p>
+    <p showWhen="form.error">
+      <strong>Error:</strong><br />
+      <span replaceWith="form.errorMessage" />
+    </p>
+    <p>
+      <input type="submit" value="Request Password reset" />
+    </p>
+  </div>
+</ResetPasswordForm>
+```
+
+If you want to handle the form `onSubmit()` event, then simply provide a callback for it.
+
+```javascript
+class LoginPage extends React.Component {
+  onFormSubmit(e, next) {
+    // e.data will contain the data mapped from your form.
+    console.log("Form submitted", e.data);
+
+    // To return an error message, call next() as:
+    // next(new Error('Something in the form is wrong.'));
+
+    // Or if you want to change the data being sent, call it as:
+    // next(null, { myNewData: '123' });
+
+    // If you call next without any arguments,
+    // it will simply proceed processing the form.
+    next();
+  }
+
+  render() {
+    return <ResetPasswordForm onSubmit={this.onFormSubmit.bind(this)} />;
+  }
+}
+```
+
 #### VerifyEmailView
 
 Renders an email verification view. The parameter `spToken` is required in order for the token to be validated.

--- a/src/components/ResetPasswordForm.js
+++ b/src/components/ResetPasswordForm.js
@@ -1,76 +1,152 @@
 import React from 'react';
+import ReactMixin from 'react-mixin';
+import { History, Link } from 'react-router';
 
-import LoginLink from './LoginLink';
+import Utils from '../utils';
+import LoginLink from '../components/LoginLink';
 import UserActions from '../actions/UserActions';
 
+class DefaultResetPasswordForm extends React.Component {
+  render() {
+    return (
+      <ResetPasswordForm {...this.props}>
+        <div className='sp-reset-password-form'>
+          <div className="row">
+            <div className="col-sm-offset-4 col-xs-12 col-sm-4" showWhen="form.sent">
+              <p className="alert alert-success">
+                We have sent a password reset link to the email address of the account that you specified.
+                Please check your email for this message, then click on the link.
+              </p>
+              <p className="pull-right">
+                <LoginLink>Back to Login</LoginLink>
+              </p>
+            </div>
+            <div className="col-xs-12" showWhen="!form.sent">
+              <div className="form-horizontal">
+                <div className="form-group">
+                  <label htmlFor="spEmail" className="col-xs-12 col-sm-4 control-label">Email or Username</label>
+                  <div className="col-xs-12 col-sm-4">
+                    <input className="form-control" id="spEmail" name="email" placeholder="Your Email Address" />
+                  </div>
+                </div>
+                <div className="form-group">
+                  <div className="col-sm-offset-4 col-xs-12">
+                    <p showWhen="form.error"><span replaceWith="form.errorMessage" /></p>
+                    <button type="submit" className="btn btn-primary">Request Password Reset</button>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </ResetPasswordForm>
+    );
+  }
+}
+
+@ReactMixin.decorate(History)
 export default class ResetPasswordForm extends React.Component {
   state = {
     fields: {
       email: ''
     },
-    isRequestSent: false,
-    errorMessage: null
+    errorMessage: null,
+    isFormProcessing: false,
+    isFormSent: false
   };
 
   onFormSubmit(e) {
-    var self = this;
     e.preventDefault();
 
-    UserActions.forgotPassword(this.state.fields, function (err) {
+    var next = (err, data) => {
       if (err) {
-        self.setState({ errorMessage: err.message });
-        return;
+        return this.setState({
+          isFormProcessing: false,
+          errorMessage: err.message
+        });
       }
-      self.setState({ isRequestSent: true });
+
+      // If the user didn't specify any data,
+      // then simply default to what we have in state.
+      data = data || this.state.fields;
+
+      UserActions.forgotPassword(this.state.fields, (err) => {
+        if (err) {
+          this.setState({
+            errorMessage: err.message
+          });
+        } else {
+          this.setState({
+            isFormSent: true
+          });
+        }
+      });
+    };
+
+    this.setState({
+      isFormProcessing: true
     });
+
+    if (this.props.onSubmit) {
+      e.data = this.state.fields;
+      this.props.onSubmit(e, next);
+    } else {
+      next(null, this.state.fields);
+    }
   }
 
-  onEmailChanged(e) {
-    this.state.fields.email = e.target.value;
+  _mapFormFieldHandler(element, tryMapField) {
+    if (['input', 'textarea'].indexOf(element.type) > -1) {
+      if (element.props.type !== 'submit') {
+        switch(element.props.name) {
+          case 'email':
+            tryMapField('email');
+            break;
+        }
+      }
+    }
+  }
+
+  _showWhenHandler(action, element) {
+    var test = null;
+
+    switch (action) {
+      case 'form.processing':
+        test = this.state.isFormProcessing;
+        break;
+      case 'form.sent':
+        test = this.state.isFormSent;
+        break;
+      case 'form.error':
+        test = !!this.state.errorMessage;
+        break;
+    }
+
+    return test;
+  }
+
+  _replaceWithHandler(action, element) {
+    var element = false;
+
+    switch (action) {
+      case 'form.errorMessage':
+        var className = element.props ? element.props.className : undefined;
+        element = <span className={className}>{this.state.errorMessage}</span>;
+        break;
+    }
+
+    return element;
   }
 
   render() {
-    return (
-      <div className="row">
-        { this.state.isRequestSent ?
-          <div className="col-sm-offset-4 col-xs-12 col-sm-4">
-            { this.state.errorMessage === null ?
-              <div>
-                <p className="alert alert-success">
-                  We have sent a password reset link to the email address of the account that you specified.
-                  Please check your email for this message, then click on the link.
-                </p>
-                <p className="pull-right">
-                  <LoginLink>Back to Login</LoginLink>
-                </p>
-              </div>
-            :
-              <div className="alert alert-danger">
-                Sorry, there was a problem with that email or username.  Please try again.
-              </div>
-            }
-          </div>
-        :
-          <div className="col-xs-12">
-            <form className="form-horizontal" onSubmit={this.onFormSubmit.bind(this)}>
-              <div className="form-group">
-                <label htmlFor="spEmail" className="col-xs-12 col-sm-4 control-label">Email or Username</label>
-                <div className="col-xs-12 col-sm-4">
-                  <input className="form-control" id="spEmail" onChange={this.onEmailChanged.bind(this)} placeholder="Your Email Address" />
-                </div>
-              </div>
-              <div className="form-group">
-                <div className="col-sm-offset-4 col-xs-12">
-                  { this.state.errorMessage ?
-                    <p className="text-danger">{ this.state.errorMessage }</p>
-                  : null }
-                  <button type="submit" className="btn btn-primary">Request Password Reset</button>
-                </div>
-              </div>
-            </form>
-          </div>
-        }
-      </div>
-    );
+    if (this.props.children) {
+      return (
+        <form onSubmit={this.onFormSubmit.bind(this)}>
+          {Utils.makeForm(this, this._mapFormFieldHandler.bind(this), this._showWhenHandler.bind(this), this._replaceWithHandler.bind(this))}
+        </form>
+      );
+    } else {
+      return <DefaultResetPasswordForm {...this.props} />;
+    }
   }
 }

--- a/src/components/ResetPasswordForm.js
+++ b/src/components/ResetPasswordForm.js
@@ -12,7 +12,7 @@ class DefaultResetPasswordForm extends React.Component {
       <ResetPasswordForm {...this.props}>
         <div className='sp-reset-password-form'>
           <div className="row">
-            <div className="col-sm-offset-4 col-xs-12 col-sm-4" showWhen="form.sent">
+            <div className="col-sm-offset-4 col-xs-12 col-sm-4" spIf="form.sent">
               <p className="alert alert-success">
                 We have sent a password reset link to the email address of the account that you specified.
                 Please check your email for this message, then click on the link.
@@ -21,7 +21,7 @@ class DefaultResetPasswordForm extends React.Component {
                 <LoginLink>Back to Login</LoginLink>
               </p>
             </div>
-            <div className="col-xs-12" showWhen="!form.sent">
+            <div className="col-xs-12" spIf="!form.sent">
               <div className="form-horizontal">
                 <div className="form-group">
                   <label htmlFor="spEmail" className="col-xs-12 col-sm-4 control-label">Email or Username</label>
@@ -31,7 +31,7 @@ class DefaultResetPasswordForm extends React.Component {
                 </div>
                 <div className="form-group">
                   <div className="col-sm-offset-4 col-xs-12">
-                    <p showWhen="form.error"><span replaceWith="form.errorMessage" /></p>
+                    <p spIf="form.error"><span spBind="form.errorMessage" /></p>
                     <button type="submit" className="btn btn-primary">Request Password Reset</button>
                   </div>
                 </div>
@@ -73,11 +73,14 @@ export default class ResetPasswordForm extends React.Component {
       UserActions.forgotPassword(this.state.fields, (err) => {
         if (err) {
           this.setState({
+            isFormProcessing: false,
             errorMessage: err.message
           });
         } else {
           this.setState({
-            isFormSent: true
+            isFormSent: true,
+            isFormProcessing: false,
+            errorMessage: null
           });
         }
       });
@@ -96,7 +99,7 @@ export default class ResetPasswordForm extends React.Component {
   }
 
   _mapFormFieldHandler(element, tryMapField) {
-    if (['input', 'textarea'].indexOf(element.type) > -1) {
+    if (element.type === 'input' || element.type === 'textarea') {
       if (element.props.type !== 'submit') {
         switch(element.props.name) {
           case 'email':
@@ -107,7 +110,7 @@ export default class ResetPasswordForm extends React.Component {
     }
   }
 
-  _showWhenHandler(action, element) {
+  _spIfHandler(action, element) {
     var test = null;
 
     switch (action) {
@@ -118,19 +121,19 @@ export default class ResetPasswordForm extends React.Component {
         test = this.state.isFormSent;
         break;
       case 'form.error':
-        test = !!this.state.errorMessage;
+        test = this.state.errorMessage !== null;
         break;
     }
 
     return test;
   }
 
-  _replaceWithHandler(action, element) {
+  _spBindHandler(action, element) {
     var element = false;
 
     switch (action) {
       case 'form.errorMessage':
-        var className = element.props ? element.props.className : undefined;
+        let className = element.props ? element.props.className : undefined;
         element = <span className={className}>{this.state.errorMessage}</span>;
         break;
     }
@@ -142,7 +145,7 @@ export default class ResetPasswordForm extends React.Component {
     if (this.props.children) {
       return (
         <form onSubmit={this.onFormSubmit.bind(this)}>
-          {Utils.makeForm(this, this._mapFormFieldHandler.bind(this), this._showWhenHandler.bind(this), this._replaceWithHandler.bind(this))}
+          {Utils.makeForm(this, this._mapFormFieldHandler.bind(this), this._spIfHandler.bind(this), this._spBindHandler.bind(this))}
         </form>
       );
     } else {


### PR DESCRIPTION
Adds the ability to customize the `ResetPasswordForm` component with own `onSubmit()` function and content markup.

For documentation, see: https://github.com/stormpath/stormpath-sdk-react/blob/feature-custom-reset-password-form/docs/api.md#resetpasswordform
#### Before reviewing

Before this is reviewed we need to merge in #19 ([Feature: Custom registration form](https://github.com/stormpath/stormpath-sdk-react/pull/19)). The same discussion as in #19 also applies to this PR.

Also, the example is currently not handling the change password link in the email from the password reset request. So simply ignore this when reviewing this PR. The important thing to review is that the form works as expected.
#### How to verify
1. Clone this repo and checkout this branch.
2. Build this project by running `$ npm run build`.
3. Run `$ npm link` to make this the module to link to when running `$ npm link react-stormpath`.
4. Clone the [React example project](https://github.com/stormpath/stormpath-express-react-example).
5. Run `$ npm link react-stormpath` to link to our SDK.
6. Run `$ npm start` to host the example project.
7. Open up your browser and navigate to [http://localhost:3000/](http://localhost:3000/).
8. Navigate to the reset password page and try to reset the password for an existing user.
9. Customize the ResetPasswordForm on the ResetPasswordPage component according to the following docs: https://github.com/stormpath/stormpath-sdk-react/blob/feature-custom-reset-password-form/docs/api.md#resetpasswordform.
10. Repeat steps 6 to 8.
