### PR TITLE
Feature: Add support for HomeRoute

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,20 @@ Stormpath already integrated!*
   <AuthenticatedRoute path='/protected' component={ProtectedPage} />
   ```
 
+  Now we have most of our routes setup, let's add the route to redirect to when logging out.
+
+  ```html
+  <HomeRoute path='/' component={HomePage} />
+  ```
+
+  Add an additional `HomeRoute` and wrap it inside an `AuthenticatedRoute` to specify the route to redirect to when signing up or logging in. If this is left out then the first unauthenticated `HomeRoute` is used.
+
+  ```html
+  <AuthenticatedRoute>
+    <HomeRoute path='/profile' component={ProfilePage} />
+  </AuthenticatedRoute>
+  ```
+
 7. **Add Login and Logout Links**
 
   Use the [`LoginLink`][] component to create a link that will navigate your users to the [`LoginRoute`][] route:

--- a/docs/api.md
+++ b/docs/api.md
@@ -44,9 +44,25 @@ Router that extends `ReactRouter` with Stormpath routing functionality.
 </Router>
 ```
 
+#### HomeRoute
+
+Route to redirect to when logging out.
+
+```html
+<HomeRoute path='/' component={MainPage} />
+```
+
+Wrap the `HomeRoute` in an `AuthenticatedRoute` to specify the route you want to redirect to when you register or login.
+
+```html
+<AuthenticatedRoute>
+  <HomeRoute path='/profile' component={ProfilePage} />
+</AuthenticatedRoute>
+```
+
 #### AuthenticatedRoute
 
-Route that when used, requires that a session is established before continuing. Else redirects the user to the login route.
+Route that when used, requires that a session is established before continuing. Else redirects the user to the `LoginRoute` path.
 
 ```html
 <AuthenticatedRoute path='/home/protected' component={RegisterPage} />
@@ -66,6 +82,12 @@ Route that when accessed, ends the user session.
 
 ```html
 <LogoutRoute path='/logout' />
+```
+
+Specify `redirectTo` to set the path to redirect to after logging out. If this isn't specified, then it falls back to the unauthenticated `HomeRoute` path.
+
+```html
+<LogoutRoute redirectTo='/pathToRedirectTo' />
 ```
 
 ## Components
@@ -95,7 +117,13 @@ Renders any child components if there isn't an established user session.
 Renders a username and password login form.
 
 ```html
-<LoginForm redirectTo="/home" />
+<LoginForm />
+```
+
+Specify `redirectTo` to set the path to redirect to after logging in. If this isn't specified, then it falls back to the authenticated `HomeRoute` path.
+
+```html
+<LoginForm redirectTo='/pathToRedirectTo' />
 ```
 
 Customize the form by providing your own markup.
@@ -153,12 +181,17 @@ Renders a registration form.
 <RegistrationForm />
 ```
 
+Specify `redirectTo` to set the path to redirect to after registering.  If this isn't specified, then it falls back to the authenticated `HomeRoute` path.
+
+```html
+<RegistrationForm redirectTo='/pathToRedirectTo' />
+```
+
 Customize the form by providing your own markup.
 
 ```html
 <RegistrationForm>
   <div spIf="account.created">
-    <span spIf="account.enabled">Your account has been created. Please proceed to <LoginLink />.</span>
     <span spIf="!account.enabled">To verify your account, click the verification link that we sent to your email then proceed to login by going to <LoginLink />.</span>
   </div>
   <div spIf="!account.created">

--- a/src/components/AuthenticatedRoute.js
+++ b/src/components/AuthenticatedRoute.js
@@ -6,13 +6,13 @@ import UserStore from './../stores/UserStore';
 export default class AuthenticatedRoute extends Route {
   static defaultProps = {
     onEnter(nextState, replaceState, callback) {
-      var router = Context.getInstance().getRouter();
+      UserStore.isAuthenticated((err, authenticated) => {
+        if (!authenticated) {
+          var router = Context.getInstance().getRouter();
+          var homeRoute = router.getHomeRoute();
+          var loginRoute = router.getLoginRoute();
+          var redirectTo = (loginRoute || {}).path || (homeRoute || {}).path || '/';
 
-      var loginRoute = router.getLoginRoute();
-      var redirectTo = (loginRoute ? loginRoute.path : this.redirectTo) || '/';
-
-      UserStore.isAuthenticated(function (err, authenticated) {
-        if (err || !authenticated) {
           replaceState({ nextPathname: nextState.location.pathname }, redirectTo);
         }
         callback();

--- a/src/components/HomeRoute.js
+++ b/src/components/HomeRoute.js
@@ -1,0 +1,4 @@
+import { Route } from 'react-router';
+
+export default class HomeRoute extends Route {
+}

--- a/src/components/LoginForm.js
+++ b/src/components/LoginForm.js
@@ -2,7 +2,8 @@ import React from 'react';
 import ReactMixin from 'react-mixin';
 import { History, Link } from 'react-router';
 
-import Utils from '../utils';
+import utils from '../utils';
+import Context from '../Context';
 import UserActions from '../actions/UserActions';
 
 class DefaultLoginForm extends React.Component {
@@ -71,13 +72,14 @@ export default class LoginForm extends React.Component {
         username: data.username,
         password: data.password
       }, (err, result) => {
-        this.setState({ isFormProcessing: false });
-
         if (err) {
-          this.setState({ errorMessage: err.message });
-        } else {
-          this.history.pushState(null, this.props.redirectTo || '/');
+          return this.setState({
+            isFormProcessing: false,
+            errorMessage: err.message
+          });
         }
+
+        this._performRedirect();
       });
     };
 
@@ -91,6 +93,15 @@ export default class LoginForm extends React.Component {
     } else {
       next(null, this.state.fields);
     }
+  }
+
+  _performRedirect() {
+    var router = Context.getInstance().getRouter();
+    var homeRoute = router.getHomeRoute();
+    var authenticatedHomeRoute = router.getAuthenticatedHomeRoute();
+    var redirectTo = this.props.redirectTo || (authenticatedHomeRoute || {}).path || (homeRoute || {}).path || '/';
+
+    this.history.pushState(null, redirectTo);
   }
 
   _mapFormFieldHandler(element, tryMapField) {
@@ -141,7 +152,7 @@ export default class LoginForm extends React.Component {
     if (this.props.children) {
       return (
         <form onSubmit={this.onFormSubmit.bind(this)}>
-          {Utils.makeForm(this, this._mapFormFieldHandler.bind(this), this._spIfHandler.bind(this), this._spBindHandler.bind(this))}
+          {utils.makeForm(this, this._mapFormFieldHandler.bind(this), this._spIfHandler.bind(this), this._spBindHandler.bind(this))}
         </form>
       );
     } else {

--- a/src/components/LoginLink.js
+++ b/src/components/LoginLink.js
@@ -8,7 +8,7 @@ export default class LoginLink extends React.Component {
     var router = Context.getInstance().getRouter();
 
     var loginRoute = router.getLoginRoute();
-    var targetPath = loginRoute ? loginRoute.path : '/login';
+    var targetPath = (loginRoute || {}).path || '/login';
 
   	return (
       <Link to={targetPath} className={this.props.className}>

--- a/src/components/LoginRoute.js
+++ b/src/components/LoginRoute.js
@@ -1,4 +1,22 @@
 import { Route } from 'react-router';
 
+import Context from './../Context';
+import UserStore from './../stores/UserStore';
+
 export default class LoginRoute extends Route {
+  static defaultProps = {
+    onEnter(nextState, replaceState, callback) {
+      UserStore.isAuthenticated((err, authenticated) => {
+        if (authenticated) {
+          var router = Context.getInstance().getRouter();
+          var homeRoute = router.getHomeRoute();
+          var authenticatedHomeRoute = router.getAuthenticatedHomeRoute();
+          var redirectTo = (authenticatedHomeRoute || {}).path || (homeRoute || {}).path || '/';
+
+          replaceState({ nextPathname: nextState.location.pathname }, redirectTo);
+        }
+        callback();
+      });
+    }
+  };
 }

--- a/src/components/LogoutLink.js
+++ b/src/components/LogoutLink.js
@@ -8,7 +8,7 @@ export default class LogoutLink extends React.Component {
     var router = Context.getInstance().getRouter();
 
     var logoutRoute = router.getLogoutRoute();
-    var targetPath = logoutRoute ? logoutRoute.path : '/logout';
+    var targetPath = (logoutRoute || {}).path || '/logout';
 
   	return (
       <Link to={targetPath} className={this.props.className}>

--- a/src/components/LogoutRoute.js
+++ b/src/components/LogoutRoute.js
@@ -7,13 +7,14 @@ import UserActions from './../actions/UserActions';
 export default class LogoutRoute extends Route {
   static defaultProps = {
     onEnter(nextState, replaceState, callback) {
-      var router = Context.getInstance().getRouter();
+      UserActions.logout(() => {
+        var router = Context.getInstance().getRouter();
+        var homeRoute = router.getHomeRoute();
+        var loginRoute = router.getLoginRoute();
+        var redirectTo = this.redirectTo || (homeRoute || {}).path || (loginRoute || {}).path || '/';
 
-      var loginRoute = router.getLoginRoute();
-      var redirectTo = (loginRoute ? loginRoute.path : this.redirectTo) || '/';
-
-      UserActions.logout(function () {
         replaceState({ nextPathname: nextState.location.pathname }, redirectTo);
+
         callback();
       });
     }

--- a/src/components/RegistrationForm.js
+++ b/src/components/RegistrationForm.js
@@ -2,7 +2,8 @@ import React from 'react';
 import ReactMixin from 'react-mixin';
 import { History, Link } from 'react-router';
 
-import Utils from '../utils';
+import utils from '../utils';
+import Context from './../Context';
 import LoginLink from '../components/LoginLink';
 import UserActions from '../actions/UserActions';
 
@@ -115,11 +116,7 @@ export default class RegistrationForm extends React.Component {
               });
             }
 
-            this.setState({
-              isFormProcessing: false,
-              isAccountCreated: true,
-              isAccountEnabled: true
-            });
+            this._performRedirect();
           });
         } else {
           this.setState({
@@ -141,6 +138,15 @@ export default class RegistrationForm extends React.Component {
     } else {
       next(null, this.state.fields);
     }
+  }
+
+  _performRedirect() {
+    var router = Context.getInstance().getRouter();
+    var homeRoute = router.getHomeRoute();
+    var authenticatedHomeRoute = router.getAuthenticatedHomeRoute();
+    var redirectTo = this.props.redirectTo || (authenticatedHomeRoute || {}).path || (homeRoute || {}).path || '/';
+
+    this.history.pushState(null, redirectTo);
   }
 
   _mapFormFieldHandler(element, tryMapField) {
@@ -208,7 +214,7 @@ export default class RegistrationForm extends React.Component {
     if (this.props.children) {
       return (
         <form onSubmit={this.onFormSubmit.bind(this)}>
-          {Utils.makeForm(this, this._mapFormFieldHandler.bind(this), this._spIfHandler.bind(this), this._spBindHandler.bind(this))}
+          {utils.makeForm(this, this._mapFormFieldHandler.bind(this), this._spIfHandler.bind(this), this._spBindHandler.bind(this))}
         </form>
       );
     } else {

--- a/src/components/ResetPasswordForm.js
+++ b/src/components/ResetPasswordForm.js
@@ -2,7 +2,7 @@ import React from 'react';
 import ReactMixin from 'react-mixin';
 import { History, Link } from 'react-router';
 
-import Utils from '../utils';
+import utils from '../utils';
 import LoginLink from '../components/LoginLink';
 import UserActions from '../actions/UserActions';
 
@@ -145,7 +145,7 @@ export default class ResetPasswordForm extends React.Component {
     if (this.props.children) {
       return (
         <form onSubmit={this.onFormSubmit.bind(this)}>
-          {Utils.makeForm(this, this._mapFormFieldHandler.bind(this), this._spIfHandler.bind(this), this._spBindHandler.bind(this))}
+          {utils.makeForm(this, this._mapFormFieldHandler.bind(this), this._spIfHandler.bind(this), this._spBindHandler.bind(this))}
         </form>
       );
     } else {

--- a/src/components/Router.js
+++ b/src/components/Router.js
@@ -1,12 +1,24 @@
 import ReactRouter from 'react-router';
 
+import utils from './../utils';
 import Context from './../Context';
 
+import HomeRoute from './HomeRoute';
 import LoginRoute from './LoginRoute';
 import LogoutRoute from './LogoutRoute';
+import AuthenticatedRoute from './AuthenticatedRoute';
 
 export default class Router extends ReactRouter {
   markedRoutes = {
+    home: {
+      type: HomeRoute,
+      authenticated: {
+        props: null
+      },
+      notAuthenticated: {
+        props: null
+      }
+    },
     login: {
       type: LoginRoute,
       props: null
@@ -26,28 +38,34 @@ export default class Router extends ReactRouter {
   _mapMarkedRoutes() {
     var markedRoutes = this.markedRoutes;
 
-    function getChildren(node) {
-      if (!node.props.children || !node.props.children.props || !node.props.children.props.children) {
-        return [];
-      }
-      return node.props.children.props.children;
-    }
-
-    function walk(node) {
-      // Try and map the node to a marked route
+    utils.deepForEach(this, (node, parent) => {
+      // Try and map the route node to a marked route.
       for (var routeName in markedRoutes) {
         var route = markedRoutes[routeName];
-        if (node.type == route.type) {
-          markedRoutes[routeName].props = node.props;
+        if (node.type === route.type) {
+          var markedRoute = markedRoutes[routeName];
+
+          if (node.type === HomeRoute) {
+            if (parent.type === AuthenticatedRoute) {
+              markedRoute = markedRoute.authenticated;
+            } else {
+              markedRoute = markedRoute.notAuthenticated;
+            }
+          }
+
+          markedRoute.props = node.props;
           break;
         }
       }
+    });
+  }
 
-      // Walk children
-      getChildren(node).forEach(walk);
-    }
+  getHomeRoute() {
+    return this.markedRoutes.home.notAuthenticated.props;
+  }
 
-    walk(this);
+  getAuthenticatedHomeRoute() {
+    return this.markedRoutes.home.authenticated.props;
   }
 
   getLoginRoute() {

--- a/src/index.js
+++ b/src/index.js
@@ -6,6 +6,7 @@ export Router from './components/Router';
 export actions from './actions/UserActions';
 export constants from './constants/UserConstants';
 
+export HomeRoute from './components/HomeRoute';
 export LoginRoute from './components/LoginRoute';
 export LogoutRoute from './components/LogoutRoute';
 export AuthenticatedRoute from './components/AuthenticatedRoute';

--- a/src/utils.js
+++ b/src/utils.js
@@ -3,12 +3,19 @@ import React from 'react';
 class Utils {
   nopElement = <span />;
 
-  forEachChild(children, handler) {
+  deepForEach(node, handler) {
+    handler(node);
+    if (node.props.children) {
+      this.forEachChild(node.props.children, handler, node);
+    }
+  }
+
+  forEachChild(children, handler, parent) {
     React.Children.forEach(children, (child) => {
-      handler(child);
+      handler(child, parent);
 
       if (child.props && child.props.children) {
-        this.forEachChild(child.props.children, handler);
+        this.forEachChild(child.props.children, handler, child);
       }
     });
   }


### PR DESCRIPTION
Adds support for `HomeRoute`. The route to redirect to after registration, login, or logout.
##### How to verify
1. Clone this repo and checkout this branch.
2. Build this project by running `$ npm run build`.
3. Run `$ npm link` to make this the module to link to when running `$ npm link react-stormpath`.
4. Clone the [React example project](https://github.com/stormpath/stormpath-express-react-example).
5. Run `$ npm link react-stormpath` to link to our SDK.
6. Run `$ npm start` to host the example project.
7. Open up your browser and navigate to [http://localhost:3000/](http://localhost:3000/).
8. Navigate to the registration page and try to register. Verify that you're being redirected to the right page.
9. Navigate to the login page and try to log in. Verify that you're being redirected to the right page.
10. Navigate to the logout page. Verify that you're being redirected to the right page.
11. Customize the router with `HomeRoute`s according to the following docs: https://github.com/stormpath/stormpath-sdk-react/blob/feature-home-route-support/docs/api.md#homeroute.
12. Repeat steps 6 to 10.

Fixes #15.
