### PR TITLE
Feature: Add ability to configure services base uri

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -19,6 +19,7 @@ ReactStormpath.init({
   // Optional: Set if you want to to use another API endpoint.
   // Values shown below are the defaults.
   endpoints: {
+    baseUri: null,
     me: '/me',
     login: '/login',
     register: '/register',

--- a/src/services/UserService.js
+++ b/src/services/UserService.js
@@ -75,6 +75,7 @@ export default class UserService {
     this.meRequestPool = new RequestPool();
 
     this.endpoints = {
+      baseUri: null,
       me: '/me',
       login: '/login',
       register: '/register',
@@ -103,33 +104,37 @@ export default class UserService {
     });
   }
 
+  _buildEndpoint(endpoint) {
+    return (this.endpoints.baseUri || '') + endpoint;
+  }
+
 	me(callback) {
     this.meRequestPool.request((resultCallback) => {
-      this._makeRequest('get', this.endpoints.me, null, resultCallback);
+      this._makeRequest('get', this._buildEndpoint(this.endpoints.me), null, resultCallback);
     }, callback);
 	}
 
 	login(options, callback) {
-    this._makeRequest('post', this.endpoints.login, options, callback);
+    this._makeRequest('post', this._buildEndpoint(this.endpoints.login), options, callback);
 	}
 
   register(options, callback) {
-    this._makeRequest('post', this.endpoints.register, options, callback);
+    this._makeRequest('post', this._buildEndpoint(this.endpoints.register), options, callback);
   }
 
   verifyEmail(spToken, callback) {
-    this._makeRequest('get', this.endpoints.verifyEmail + '?sptoken=' + encodeURIComponent(spToken), null, callback);
+    this._makeRequest('get', this._buildEndpoint(this.endpoints.verifyEmail + '?sptoken=' + encodeURIComponent(spToken)), null, callback);
   }
 
   forgotPassword(options, callback) {
-    this._makeRequest('post', this.endpoints.forgotPassword, options, callback);
+    this._makeRequest('post', this._buildEndpoint(this.endpoints.forgotPassword), options, callback);
   }
 
   changePassword(options, callback) {
-    this._makeRequest('post', this.endpoints.changePassword, options, callback);
+    this._makeRequest('post', this._buildEndpoint(this.endpoints.changePassword), options, callback);
   }
 
 	logout(callback) {
-    this._makeRequest('get', this.endpoints.logout, null, callback);
+    this._makeRequest('get', this._buildEndpoint(this.endpoints.logout), null, callback);
 	}
 }


### PR DESCRIPTION
Adds the ability to configure a service base URI.
##### How to verify
1. Clone this repo and checkout this branch.
2. Build this project by running `$ npm run build`.
3. Run `$ npm link` to make this the module to link to when running `$ npm link react-stormpath`.
4. Clone the [React example project](https://github.com/stormpath/stormpath-express-react-example).
5. Run `$ npm link react-stormpath` to link to our SDK.
6. Open up the example project and modify the `ReactStormpath.init(...)` to include the `baseUri` parameter as shown in [the API docs](https://github.com/stormpath/stormpath-sdk-react/blob/feature-service-base-uri/docs/api.md#initialization). Set the `baseUri` to something like `http://api.somedomain.com`.
7. Run `$ npm start` to host the example project.
8. Open up your browser and navigate to [http://localhost:3000/](http://localhost:3000/).
9. Check the browser network tab, and assert that API calls for `http://api.somedomain.com` is being called (even if failing).
