### PR TITLE
Feature: Add X-Stormpath-Agent header

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,23 +21,20 @@
   "bugs": "https://github.com/stormpath/stormpath-sdk-react/issues",
   "scripts": {
     "build": "npm run build-cjs && npm run build-es6 && npm run build-umd && npm run build-min",
-    "build-cjs": "rimraf lib && node ./node_modules/babel-cli/lib/babel ./src -d lib",
-    "build-es6": "rimraf es6 && node ./node_modules/babel-cli/lib/babel ./src -d es6",
+    "build-cjs": "NODE_ENV=production webpack --output-library-target commonjs2 src/index.js ./lib/index.js",
+    "build-es6": "NODE_ENV=production webpack --output-library-target commonjs2 src/index.js ./es6/index.js",
     "build-umd": "NODE_ENV=production webpack src/index.js umd/stormpath-sdk-react.js",
     "build-min": "NODE_ENV=production webpack -p src/index.js umd/stormpath-sdk-react.min.js",
-    "build-dist": "NODE_ENV=production webpack src/index.js dist/stormpath-sdk-react.js && NODE_ENV=production webpack -p src/index.js dist/stormpath-sdk-react.min.js",
-    "lint": "eslint src examples"
+    "build-dist": "NODE_ENV=production webpack src/index.js dist/stormpath-sdk-react.js && NODE_ENV=production webpack -p src/index.js dist/stormpath-sdk-react.min.js"
   },
-  "dependencies": {
+  "devDependencies": {
     "flux": "^2.1.1",
     "globals": "^8.16.0",
     "invariant": "^2.2.0",
     "keymirror": "^0.1.1",
     "react-mixin": "^3.0.3",
     "react-router": "^1.0.3",
-    "warning": "^2.1.0"
-  },
-  "devDependencies": {
+    "warning": "^2.1.0",
     "babel-cli": "^6.3.17",
     "babel-core": "^6.3.26",
     "babel-eslint": "^5.0.0-beta6",
@@ -62,7 +59,6 @@
     "react-dom": "^0.14.5",
     "react-static-container": "^1.0.0",
     "react-transform-catch-errors": "^1.0.1",
-    "rimraf": "^2.5.0",
     "style-loader": "^0.13.0",
     "webpack": "^1.12.9",
     "webpack-dev-middleware": "^1.4.0"

--- a/src/services/BaseService.js
+++ b/src/services/BaseService.js
@@ -1,0 +1,84 @@
+import React from 'react';
+import utils from '../utils';
+
+function makeHttpRequest(method, uri, body, headers, callback) {
+  var request = new XMLHttpRequest();
+
+  request.open(method.toUpperCase(), uri, true);
+
+  if (headers) {
+    for (var name in headers) {
+      var value = headers[name];
+      request.setRequestHeader(name, value);
+    }
+  }
+
+  request.onreadystatechange = function () {
+    // 4 = Request finished and response is ready.
+    // Ignore everything else.
+    if (request.readyState !== 4) {
+      return;
+    }
+
+    var result = {
+      status: request.status,
+      responseJSON: null
+    };
+
+    try {
+      if (request.responseText) {
+        result.responseJSON = JSON.parse(request.responseText);
+      }
+      callback(null, result);
+    } catch(e) {
+      callback(e);
+    }
+  };
+
+  if (body !== undefined) {
+    request.setRequestHeader('Content-Type', 'application/json; charset=utf-8');
+    request.send(JSON.stringify(body));
+  }
+}
+
+export default class BaseService {
+  constructor(endpoints) {
+    var defaultEndpoints = {
+      baseUri: null
+    };
+
+    this.endpoints = utils.mergeObjects(defaultEndpoints, endpoints);
+  }
+
+  _makeRequest(method, path, body, callback) {
+    var uri = this._buildEndpoint(path);
+
+    var headers = {
+      'Accept': 'application/json'
+    };
+
+    // Only set the X-Stormpath-Agent header if we're on the same domain as the requested URI.
+    // This because we want to avoid CORS requests that require you to have to whitelist the X-Stormpath-Agent header.
+    if (utils.isRelativeUri(uri) || utils.isSameHost(uri, window.location.href)) {
+      headers['X-Stormpath-Agent'] = `${pkg.name}/${pkg.version} react/${React.version}`;
+    }
+
+    makeHttpRequest(method, uri, body, headers, function (err, result) {
+      if (err) {
+        return callback(err);
+      }
+
+      var data = result.responseJSON || {};
+
+      if (result.status === 200) {
+        callback(null, data);
+      } else {
+        callback(new Error(data.error || 'Invalid request.'));
+      }
+    });
+  }
+
+  _buildEndpoint(endpoint) {
+    return (this.endpoints.baseUri || '') + endpoint;
+  }
+}

--- a/src/services/RequestPool.js
+++ b/src/services/RequestPool.js
@@ -1,0 +1,19 @@
+export default class RequestPool {
+  waiting = [];
+
+  request(resolver, callback) {
+    var waiting = this.waiting;
+
+    waiting.push(callback);
+
+    if (waiting.length === 1) {
+      resolver(function () {
+        while (waiting.length) {
+          waiting.shift().apply(null, arguments);
+        }
+      });
+    }
+
+    return false;
+  }
+}

--- a/src/services/UserService.js
+++ b/src/services/UserService.js
@@ -41,6 +41,7 @@ function makeAjaxRequest(method, path, body, callback) {
 
   request.open(method.toUpperCase(), path, true);
   request.setRequestHeader('Accept', 'application/json');
+  request.setRequestHeader('X-Stormpath-Agent', pkg.name + '/' + pkg.version);
 
   request.onreadystatechange = function () {
     // 4 = Request finished and response is ready.

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,3 +1,4 @@
+import url from 'url';
 import React from 'react';
 
 class Utils {
@@ -167,6 +168,40 @@ class Utils {
     };
 
     return this.buildElementTree(root, optionsFactory, elementFactory);
+  }
+
+  mergeObjects(obj1, obj2) {
+    var obj3 = {};
+
+    if (obj1) {
+      for (var attrname in obj1) {
+        obj3[attrname] = obj1[attrname];
+      }
+    }
+
+    if (obj2) {
+      for (var attrname in obj2) {
+        obj3[attrname] = obj2[attrname];
+      }
+    }
+
+    return obj3;
+  }
+
+  isSameHost(a, b) {
+    var urlA = url.parse(a);
+
+    if (!urlA) {
+      return false;
+    }
+
+    var urlB = url.parse(b);
+
+    if (!urlB) {
+      return false;
+    }
+
+    return urlA.host === urlB.host;
   }
 }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -188,6 +188,10 @@ class Utils {
     return obj3;
   }
 
+  isRelativeUri(uri) {
+    return uri && uri[0] === '/';
+  }
+
   isSameHost(a, b) {
     var urlA = url.parse(a);
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -28,5 +28,9 @@ module.exports = {
   },
 
   plugins: [
+    new webpack.DefinePlugin({
+      'pkg.version': JSON.stringify(require('./package.json').version),
+      'pkg.name': JSON.stringify(require('./package.json').name)
+    })
   ]
 };


### PR DESCRIPTION
Adds the X-Stormpath-Agent header to all API requests.
##### How to verify
1. Checkout this branch.
2. Link it (`$ npm link`).
3. Clone [the React example app](https://github.com/stormpath/stormpath-express-react-example).
4. Link to the feature branch (`$ npm link react-stormpath`).
5. Start the app (`$ npm start`).
6. Navigate to the login page.
7. Open up the network console and try to login.
8. Assert that the POST request to `/login` contains the header `X-Stormpath-Agent: react-stormpath/0.5.0`.

Fixes #30.
