### PR TITLE
Add support for the login view model

### DIFF
--- a/src/components/LoadingText.js
+++ b/src/components/LoadingText.js
@@ -5,7 +5,7 @@ export default class LoadingText extends React.Component {
 
   state = {
     text: null
-  }
+  };
 
   componentDidMount() {
     this.waitTimeout = setTimeout(() => {

--- a/src/components/LoadingText.js
+++ b/src/components/LoadingText.js
@@ -1,0 +1,31 @@
+import React from 'react';
+
+export default class LoadingText extends React.Component {
+  waitTimeout = null;
+
+  state = {
+    text: null
+  }
+
+  componentDidMount() {
+    this.waitTimeout = setTimeout(() => {
+      this.setState({
+        text: this.props.text || 'Loading...'
+      });
+    }, this.props.showAfter || 250);
+  }
+
+  componentWillUnmount() {
+    clearTimeout(this.waitTimeout);
+  }
+
+  render() {
+    if (!this.state.text) {
+      return null;
+    }
+
+    return (
+      <p style={{ textAlign: 'center' }}>{ this.state.text }</p>
+    );
+  }
+}

--- a/src/components/LoginForm.js
+++ b/src/components/LoginForm.js
@@ -4,35 +4,79 @@ import { History, Link } from 'react-router';
 
 import utils from '../utils';
 import Context from '../Context';
+import UserStore from '../stores/UserStore';
 import UserActions from '../actions/UserActions';
+import LoadingText from '../components/LoadingText';
 
 class DefaultLoginForm extends React.Component {
+  state = {
+    fields: null
+  };
+
+  componentDidMount() {
+    if (this.state.fields !== null) {
+      return;
+    }
+
+    var defaultFields = [
+      {
+        label: 'Username or Email',
+        name: 'login',
+        placeholder: 'Username or Email',
+        required: true,
+        type: 'text'
+      }, {
+        label: 'Password',
+        name: 'password',
+        placeholder: 'Password',
+        required: true,
+        type: 'password'
+      }
+    ];
+
+    UserStore.getLoginViewData((err, data) => {
+      this.setState({
+        fields: data && data.form ? data.form.fields : defaultFields
+      });
+    });
+  }
+
   render() {
+    var fieldMarkup = null;
+
+    if (this.state.fields !== null) {
+      fieldMarkup = [];
+
+      this.state.fields.forEach((field, index) => {
+        var fieldId = `sp-${field.name}-${index}`;
+        fieldMarkup.push(
+          <div key={ fieldId } className="form-group">
+            <label htmlFor={ fieldId } className="col-xs-12 col-sm-4 control-label">{ field.label }</label>
+            <div className="col-xs-12 col-sm-4">
+              <input type={ field.type } className="form-control" id={ fieldId } name={ field.name } placeholder={ field.placeholder } />
+            </div>
+          </div>
+        );
+      });
+
+      fieldMarkup.push(
+        <div key="login-button" className="form-group">
+          <div className="col-sm-offset-4 col-sm-4">
+            <p className="alert alert-danger" spIf="form.error"><span spBind="form.errorMessage" /></p>
+            <button type="submit" className="btn btn-primary">Login</button>
+            <Link to="/forgot" className="pull-right">Forgot Password</Link>
+          </div>
+        </div>
+      );
+    }
+
     return (
       <LoginForm {...this.props}>
         <div className='sp-login-form'>
           <div className="row">
             <div className="col-xs-12">
               <div className="form-horizontal">
-                <div className="form-group">
-                  <label htmlFor="spEmail" className="col-xs-12 col-sm-4 control-label">Email</label>
-                  <div className="col-xs-12 col-sm-4">
-                    <input className="form-control" id="spUsername" name="username" placeholder="Username or Email" />
-                  </div>
-                </div>
-                <div className="form-group">
-                  <label htmlFor="spPassword" className="col-xs-12 col-sm-4 control-label">Password</label>
-                  <div className="col-xs-12 col-sm-4">
-                    <input type="password" className="form-control" id="spPassword" name="password" placeholder="Password" />
-                  </div>
-                </div>
-                <div className="form-group">
-                  <div className="col-sm-offset-4 col-sm-4">
-                    <p className="alert alert-danger" spIf="form.error"><span spBind="form.errorMessage" /></p>
-                    <button type="submit" className="btn btn-primary">Login</button>
-                    <Link to="/forgot" className="pull-right">Forgot Password</Link>
-                  </div>
-                </div>
+                { fieldMarkup ? fieldMarkup : <LoadingText /> }
               </div>
             </div>
           </div>

--- a/src/components/LoginForm.js
+++ b/src/components/LoginForm.js
@@ -53,7 +53,7 @@ class DefaultLoginForm extends React.Component {
           <div key={ fieldId } className="form-group">
             <label htmlFor={ fieldId } className="col-xs-12 col-sm-4 control-label">{ field.label }</label>
             <div className="col-xs-12 col-sm-4">
-              <input type={ field.type } className="form-control" id={ fieldId } name={ field.name } placeholder={ field.placeholder } />
+              <input type={ field.type } className="form-control" id={ fieldId } name={ field.name } placeholder={ field.placeholder } required={ field.required } />
             </div>
           </div>
         );

--- a/src/services/UserService.js
+++ b/src/services/UserService.js
@@ -114,6 +114,10 @@ export default class UserService {
     }, callback);
 	}
 
+  getLoginViewData(callback) {
+    this._makeRequest('get', this._buildEndpoint(this.endpoints.login), null, callback);
+  }
+
 	login(options, callback) {
     this._makeRequest('post', this._buildEndpoint(this.endpoints.login), options, callback);
 	}

--- a/src/stores/UserStore.js
+++ b/src/stores/UserStore.js
@@ -29,6 +29,10 @@ class UserStore extends BaseStore {
     });
   }
 
+  getLoginViewData(callback) {
+    this.service.getLoginViewData(callback);
+  }
+
   login(options, callback) {
     this.reset();
 


### PR DESCRIPTION
Adds support for the login view model.
#### Notes

The reason why I've added [default fields](https://github.com/stormpath/stormpath-sdk-react/pull/38/files#diff-72df5629ac5288745b548aa3c4248634R21) is just so that the SDK is backwards-compatible with `stormpath-express` < v3.0.0. I.e. if the GET request to `/login` fails, then it simply defaults to the standard default form.
#### How to verify
1. Checkout this branch.
2. Build it (`$ npm run build`).
3. Link it (`$ npm link`).
4. Checkout the [`framework-spec-upgrade`](https://github.com/stormpath/express-stormpath/tree/framework-spec-upgrade) branch of `express-stormpath`.
5. Link it (`$ npm link`).
6. Checkout the [the React example app](https://github.com/stormpath/stormpath-express-react-example).
7. Link to our React SDK feature branch (`$ npm link react-stormpath`).
8. Link to our Express feature branch (`$ npm link express-stormpath`).
9. Start the app (`$ npm start`).
10. Navigate to `/login`.
11. Verify that the default login form looks and works as expected.
12. Open up app.js and modify the [`web.login.fields`](https://github.com/stormpath/express-stormpath/blob/21c1e6569c46b3a89e3cebdd3ee2df80945e8b44/lib/config.yml#L94).
13. Start the app (step 5).
14. Navigate to `/login`.
15. Verify that the login form looks and works as as configured by `web.login.fields`.

Fixes #33.
