### PR TITLE
Add support for the registration view model

### DIFF
--- a/src/components/LoadingText.js
+++ b/src/components/LoadingText.js
@@ -10,9 +10,9 @@ export default class LoadingText extends React.Component {
   componentDidMount() {
     this.waitTimeout = setTimeout(() => {
       this.setState({
-        text: this.props.text || 'Loading...'
+        text: this.props.text || 'Loading...'
       });
-    }, this.props.showAfter || 250);
+    }, this.props.showAfter || 250);
   }
 
   componentWillUnmount() {

--- a/src/services/UserService.js
+++ b/src/services/UserService.js
@@ -37,6 +37,10 @@ export default class UserService extends BaseService {
     this._makeRequest('post', this.endpoints.register, options, callback);
   }
 
+  getRegisterViewData(callback) {
+    this._makeRequest('get', this.endpoints.register, null, callback);
+  }
+
   verifyEmail(spToken, callback) {
     this._makeRequest('get', this.endpoints.verifyEmail + '?sptoken=' + encodeURIComponent(spToken), null, callback);
   }

--- a/src/stores/UserStore.js
+++ b/src/stores/UserStore.js
@@ -49,6 +49,10 @@ class UserStore extends BaseStore {
     this.service.register(options, callback);
   }
 
+  getRegisterViewData(callback) {
+    this.service.getRegisterViewData(callback);
+  }
+
   forgotPassword(options, callback) {
     this.service.forgotPassword(options, callback);
   }


### PR DESCRIPTION
Adds support for the registration view model.
#### Notes

The reason why I've added [default fields](https://github.com/stormpath/stormpath-sdk-react/pull/39/files#diff-321b051506f073aedaa2299977a038c0R22) is just so that the SDK is backwards-compatible with `stormpath-express` < v3.0.0. I.e. if the GET request to `/register` fails, then it simply defaults to the standard default form.

Also, I first named the method `getRegisterViewData` as `getRegisterationViewData`. `Registration` sounds better to me, but decided to renamed it back to `Register` because it was more consistent with the endpoint.

Any thoughts?
#### How to verify
1. Checkout this branch.
2. Build it (`$ npm run build`).
3. Link it (`$ npm link`).
4. Checkout the [`framework-spec-upgrade`](https://github.com/stormpath/express-stormpath/tree/framework-spec-upgrade) branch of `express-stormpath`.
5. Link it (`$ npm link`).
6. Checkout the [the React example app](https://github.com/stormpath/stormpath-express-react-example).
7. Link to our React SDK feature branch (`$ npm link react-stormpath`).
8. Link to our Express feature branch (`$ npm link express-stormpath`).
9. Start the app (`$ npm start`).
10. Navigate to `/register`.
11. Verify that the default registration form looks and works as expected.
12. Open up app.js and modify the [`web.register.fields`](https://github.com/stormpath/express-stormpath/blob/21c1e6569c46b3a89e3cebdd3ee2df80945e8b44/lib/config.yml#L32).
13. Start the app (step 5).
14. Navigate to `/register`.
15. Verify that the register form looks and works as as configured by `web.register.fields`.

Fixes #32.
