### PR TITLE
Add Router context support

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -91,6 +91,51 @@ Specify `redirectTo` to set the path to redirect to after logging out. If this i
 <LogoutRoute redirectTo='/pathToRedirectTo' />
 ```
 
+## Contexts
+
+#### authenticated (bool)
+
+If you want to know if there's an authenticated account, then include the `authenticated` context.
+
+```javascript
+class AuthenticatedExample extends React.Component {
+  static contextTypes = {
+    authenticated: React.PropTypes.bool
+  };
+
+  render() {
+    return (
+      <p>
+        { this.context.authenticated ?
+          'Authenticated!' :
+          'Not authenticated!'
+        }
+      </p>
+    );
+  }
+}
+```
+
+#### account (object)
+
+If you want to retrieve the authenticated account, then include the `account` context. The value will be `undefined` if there's no authenticated account.
+
+```javascript
+class AccountExample extends React.Component {
+  static contextTypes = {
+    account: React.PropTypes.object
+  };
+
+  render() {
+    return (
+      <p>
+        Hello {this.context.account.givenName}!
+      </p>
+    );
+  }
+}
+```
+
 ## Components
 
 #### Authenticated
@@ -329,23 +374,4 @@ Renders a link that points to the LogoutRoute or `/logout` if no LogoutRoute is 
 ```html
 <LogoutLink />
 <LogoutLink><img src="wrap-something-in-a-logout-link.png" /></LogoutLink>
-```
-
-## Base Components
-
-#### UserComponent
-
-Extend a component with user state.
-
-```javascript
-class HelloUser extends UserComponent {
-  render() {
-    return (
-      <p>
-      	Hello {this.state.user.username}!
-      </p>
-    );
-  }
-}
-
 ```

--- a/docs/api.md
+++ b/docs/api.md
@@ -95,7 +95,7 @@ Specify `redirectTo` to set the path to redirect to after logging out. If this i
 
 #### authenticated (bool)
 
-If you want to know if there's an authenticated account, then include the `authenticated` context.
+If you want to know if the user is authenticated or not, include the `authenticated context.
 
 ```javascript
 class AuthenticatedExample extends React.Component {
@@ -118,7 +118,7 @@ class AuthenticatedExample extends React.Component {
 
 #### account (object)
 
-If you want to retrieve the authenticated account, then include the `account` context. The value will be `undefined` if there's no authenticated account.
+If you want to retrieve the account, then include the `account` context. The value will be `undefined` if the user is not authenticated.
 
 ```javascript
 class AccountExample extends React.Component {

--- a/docs/api.md
+++ b/docs/api.md
@@ -95,7 +95,7 @@ Specify `redirectTo` to set the path to redirect to after logging out. If this i
 
 #### authenticated (bool)
 
-If you want to know if the user is authenticated or not, include the `authenticated context.
+If you want to know if the user is authenticated or not, include the `authenticated` context.
 
 ```javascript
 class AuthenticatedExample extends React.Component {
@@ -116,20 +116,20 @@ class AuthenticatedExample extends React.Component {
 }
 ```
 
-#### account (object)
+#### user (object)
 
-If you want to retrieve the account, then include the `account` context. The value will be `undefined` if the user is not authenticated.
+If you want to retrieve the user, then include the `user` context. The value will be `undefined` if the user is not authenticated.
 
 ```javascript
-class AccountExample extends React.Component {
+class UserExample extends React.Component {
   static contextTypes = {
-    account: React.PropTypes.object
+    user: React.PropTypes.object
   };
 
   render() {
     return (
       <p>
-        Hello {this.context.account.givenName}!
+        Hello {this.context.user.givenName}!
       </p>
     );
   }

--- a/src/Context.js
+++ b/src/Context.js
@@ -1,23 +1,11 @@
-let contextInstance = null;
+import SessionStore from './stores/SessionStore';
 
-export default class Context {
+class Context {
   constructor() {
-    if (contextInstance) {
-      return contextInstance;
-    }
-
     this.router = null;
     this.dispatcher = null;
     this.endpoints = null;
-
-    contextInstance = this;
-  }
-
-  static getInstance() {
-    if (!contextInstance) {
-      return new Context();
-    }
-    return contextInstance;
+    this.sessionStore = new SessionStore();
   }
 
   setRouter(router) {
@@ -44,3 +32,5 @@ export default class Context {
     return this.endpoints || {};
   }
 }
+
+export default new Context()

--- a/src/actions/UserActions.js
+++ b/src/actions/UserActions.js
@@ -1,13 +1,9 @@
-import Context from './../Context';
+import context from './../context';
 import UserConstants from './../constants/UserConstants';
 
 class UserActions {
-  constructor(context) {
-    this.context = context;
-  }
-
   login(options, callback) {
-    this.context.getDispatcher().dispatch({
+    context.getDispatcher().dispatch({
       actionType: UserConstants.USER_LOGIN,
       options: options,
       callback: callback
@@ -15,7 +11,7 @@ class UserActions {
   }
 
   register(options, callback) {
-    this.context.getDispatcher().dispatch({
+    context.getDispatcher().dispatch({
       actionType: UserConstants.USER_REGISTER,
       options: options,
       callback: callback
@@ -23,7 +19,7 @@ class UserActions {
   }
 
   forgotPassword(options, callback) {
-    this.context.getDispatcher().dispatch({
+    context.getDispatcher().dispatch({
       actionType: UserConstants.USER_FORGOT_PASSWORD,
       options: options,
       callback: callback
@@ -31,7 +27,7 @@ class UserActions {
   }
 
   verifyEmail(spToken, callback) {
-    this.context.getDispatcher().dispatch({
+    context.getDispatcher().dispatch({
       actionType: UserConstants.USER_VERIFY_EMAIL,
       options: {
         spToken: spToken
@@ -41,7 +37,7 @@ class UserActions {
   }
 
   changePassword(options, callback) {
-    this.context.getDispatcher().dispatch({
+    context.getDispatcher().dispatch({
       actionType: UserConstants.USER_CHANGE_PASSWORD,
       options: options,
       callback: callback
@@ -49,18 +45,18 @@ class UserActions {
   }
 
   set(data) {
-    this.context.getDispatcher().dispatch({
+    context.getDispatcher().dispatch({
       actionType: UserConstants.USER_SET,
       data: data
     });
   }
 
   logout(callback) {
-    this.context.getDispatcher().dispatch({
+    context.getDispatcher().dispatch({
       actionType: UserConstants.USER_LOGOUT,
       callback: callback
     });
   }
 }
 
-export default new UserActions(Context.getInstance())
+export default new UserActions()

--- a/src/app.js
+++ b/src/app.js
@@ -1,12 +1,11 @@
 import { Dispatcher } from 'flux';
 import { EventEmitter } from 'events';
 
-import Context from './Context';
+import context from './context';
 
 class App extends EventEmitter {
-  constructor(context) {
+  constructor() {
     super();
-    this.context = context;
     this.initialized = false;
   }
 
@@ -24,15 +23,15 @@ class App extends EventEmitter {
     this.initialized = true;
 
     // If there's no specified dispatcher, then just create our own one.
-    this.context.setDispatcher(options.dispatcher || new Dispatcher());
+    context.setDispatcher(options.dispatcher || new Dispatcher());
 
     // If there are any endpoints specified, then set these.
     if (options.endpoints) {
-      this.context.setEndpoints(options.endpoints);
+      context.setEndpoints(options.endpoints);
     }
 
-    this.emit('ready', this.context);
+    this.emit('ready');
   }
 }
 
-export default new App(Context.getInstance())
+export default new App()

--- a/src/components/Authenticated.js
+++ b/src/components/Authenticated.js
@@ -1,38 +1,12 @@
 import React from 'react';
-import UserStore from './../stores/UserStore';
 
 export default class Authenticated extends React.Component {
-  onChangeListener = null;
-
-  state = {
-    authenticated: null
+  static contextTypes = {
+    account: React.PropTypes.object
   };
 
-  constructor() {
-    super();
-  }
-
-  onChange() {
-    UserStore.isAuthenticated((err, authenticated) => {
-      if (this.onChangeListener !== null) {
-        this.setState({ authenticated: authenticated === true });
-      }
-    });
-  }
-
-  componentWillMount() {
-    this.onChangeListener = this.onChange.bind(this);
-    UserStore.addChangeListener(this.onChangeListener);
-    this.onChange();
-  }
-
-  componentWillUnmount() {
-    UserStore.removeChangeListener(this.onChangeListener);
-    this.onChangeListener = null;
-  }
-
   render() {
-    return this.state.authenticated === true ?
+    return this.context.account !== undefined ?
       this.props.children : null;
   }
 }

--- a/src/components/Authenticated.js
+++ b/src/components/Authenticated.js
@@ -2,11 +2,11 @@ import React from 'react';
 
 export default class Authenticated extends React.Component {
   static contextTypes = {
-    account: React.PropTypes.object
+    user: React.PropTypes.object
   };
 
   render() {
-    return this.context.account !== undefined ?
+    return this.context.user !== undefined ?
       this.props.children : null;
   }
 }

--- a/src/components/AuthenticatedRoute.js
+++ b/src/components/AuthenticatedRoute.js
@@ -1,6 +1,6 @@
 import { Route } from 'react-router';
 
-import Context from './../Context';
+import context from './../context';
 import UserStore from './../stores/UserStore';
 
 export default class AuthenticatedRoute extends Route {
@@ -8,7 +8,7 @@ export default class AuthenticatedRoute extends Route {
     onEnter(nextState, replaceState, callback) {
       UserStore.isAuthenticated((err, authenticated) => {
         if (!authenticated) {
-          var router = Context.getInstance().getRouter();
+          var router = context.getRouter();
           var homeRoute = router.getHomeRoute();
           var loginRoute = router.getLoginRoute();
           var redirectTo = (loginRoute || {}).path || (homeRoute || {}).path || '/';

--- a/src/components/LoginForm.js
+++ b/src/components/LoginForm.js
@@ -3,7 +3,8 @@ import ReactMixin from 'react-mixin';
 import { History, Link } from 'react-router';
 
 import utils from '../utils';
-import Context from '../Context';
+import context from '../context';
+
 import UserStore from '../stores/UserStore';
 import UserActions from '../actions/UserActions';
 import LoadingText from '../components/LoadingText';
@@ -140,7 +141,7 @@ export default class LoginForm extends React.Component {
   }
 
   _performRedirect() {
-    var router = Context.getInstance().getRouter();
+    var router = context.getRouter();
     var homeRoute = router.getHomeRoute();
     var authenticatedHomeRoute = router.getAuthenticatedHomeRoute();
     var redirectTo = this.props.redirectTo || (authenticatedHomeRoute || {}).path || (homeRoute || {}).path || '/';

--- a/src/components/LoginLink.js
+++ b/src/components/LoginLink.js
@@ -1,12 +1,11 @@
 import React from 'react';
 import { Link } from 'react-router';
 
-import Context from './../Context';
+import context from './../context';
 
 export default class LoginLink extends React.Component {
   render() {
-    var router = Context.getInstance().getRouter();
-
+    var router = context.getRouter();
     var loginRoute = router.getLoginRoute();
     var targetPath = (loginRoute || {}).path || '/login';
 

--- a/src/components/LoginRoute.js
+++ b/src/components/LoginRoute.js
@@ -1,6 +1,6 @@
 import { Route } from 'react-router';
 
-import Context from './../Context';
+import context from './../context';
 import UserStore from './../stores/UserStore';
 
 export default class LoginRoute extends Route {
@@ -8,7 +8,7 @@ export default class LoginRoute extends Route {
     onEnter(nextState, replaceState, callback) {
       UserStore.isAuthenticated((err, authenticated) => {
         if (authenticated) {
-          var router = Context.getInstance().getRouter();
+          var router = context.getRouter();
           var homeRoute = router.getHomeRoute();
           var authenticatedHomeRoute = router.getAuthenticatedHomeRoute();
           var redirectTo = (authenticatedHomeRoute || {}).path || (homeRoute || {}).path || '/';

--- a/src/components/LogoutLink.js
+++ b/src/components/LogoutLink.js
@@ -2,7 +2,7 @@ import React from 'react';
 import ReactMixin from 'react-mixin';
 import { History } from 'react-router';
 
-import Context from './../Context';
+import context from './../context';
 import UserActions from './../actions/UserActions';
 
 @ReactMixin.decorate(History)
@@ -12,7 +12,7 @@ export default class LogoutLink extends React.Component {
   };
 
   _performRedirect() {
-    var router = Context.getInstance().getRouter();
+    var router = context.getRouter();
     var homeRoute = router.getHomeRoute();
     var loginRoute = router.getLoginRoute();
     var redirectTo = this.props.redirectTo || (homeRoute || {}).path || (loginRoute || {}).path || '/';

--- a/src/components/LogoutRoute.js
+++ b/src/components/LogoutRoute.js
@@ -1,14 +1,14 @@
 import React from 'react';
 import ReactRouter, { Route } from 'react-router';
 
-import Context from './../Context';
+import context from './../context';
 import UserActions from './../actions/UserActions';
 
 export default class LogoutRoute extends Route {
   static defaultProps = {
     onEnter(nextState, replaceState, callback) {
       UserActions.logout(() => {
-        var router = Context.getInstance().getRouter();
+        var router = context.getRouter();
         var homeRoute = router.getHomeRoute();
         var loginRoute = router.getLoginRoute();
         var redirectTo = this.redirectTo || (homeRoute || {}).path || (loginRoute || {}).path || '/';

--- a/src/components/NotAuthenticated.js
+++ b/src/components/NotAuthenticated.js
@@ -1,9 +1,12 @@
 import React from 'react';
-import Authenticated from './Authenticated';
 
-export default class NotAuthenticated extends Authenticated {
+export default class NotAuthenticated extends React.Component {
+  static contextTypes = {
+    account: React.PropTypes.object
+  };
+
   render() {
-    return this.state.authenticated === false ?
+    return this.context.account === undefined ?
       this.props.children : null;
   }
 }

--- a/src/components/NotAuthenticated.js
+++ b/src/components/NotAuthenticated.js
@@ -2,11 +2,11 @@ import React from 'react';
 
 export default class NotAuthenticated extends React.Component {
   static contextTypes = {
-    account: React.PropTypes.object
+    user: React.PropTypes.object
   };
 
   render() {
-    return this.context.account === undefined ?
+    return this.context.user === undefined ?
       this.props.children : null;
   }
 }

--- a/src/components/RegistrationForm.js
+++ b/src/components/RegistrationForm.js
@@ -3,7 +3,8 @@ import ReactMixin from 'react-mixin';
 import { History, Link } from 'react-router';
 
 import utils from '../utils';
-import Context from './../Context';
+import context from './../context';
+
 import LoginLink from '../components/LoginLink';
 import UserStore from '../stores/UserStore';
 import UserActions from '../actions/UserActions';
@@ -188,7 +189,7 @@ export default class RegistrationForm extends React.Component {
   }
 
   _performRedirect() {
-    var router = Context.getInstance().getRouter();
+    var router = context.getRouter();
     var homeRoute = router.getHomeRoute();
     var authenticatedHomeRoute = router.getAuthenticatedHomeRoute();
     var redirectTo = this.props.redirectTo || (authenticatedHomeRoute || {}).path || (homeRoute || {}).path || '/';

--- a/src/components/Router.js
+++ b/src/components/Router.js
@@ -92,7 +92,7 @@ export default class Router extends ReactRouter {
 
   _setAccountState(account) {
     this.setState({
-      authenticated: account !== null,
+      authenticated: account !== undefined,
       account: account
     });
   }
@@ -110,6 +110,6 @@ export default class Router extends ReactRouter {
     return {
       authenticated: this.state.authenticated,
       account: this.state.account
-    }
+    };
   }
 }

--- a/src/components/Router.js
+++ b/src/components/Router.js
@@ -12,12 +12,12 @@ import AuthenticatedRoute from './AuthenticatedRoute';
 export default class Router extends ReactRouter {
   static childContextTypes = {
     authenticated: React.PropTypes.bool,
-    account: React.PropTypes.object
+    user: React.PropTypes.object
   };
 
   state = {
     authenticated: false,
-    account: undefined
+    user: undefined
   };
 
   markedRoutes = {
@@ -44,7 +44,7 @@ export default class Router extends ReactRouter {
     super(...arguments);
 
     this._mapMarkedRoutes();
-    this.accountChangeListener = this._setAccountState.bind(this);
+    this.sessionChangeListener = this._setSessionState.bind(this);
 
     context.setRouter(this);
   }
@@ -90,26 +90,26 @@ export default class Router extends ReactRouter {
     return this.markedRoutes.logout.props;
   }
 
-  _setAccountState(account) {
+  _setSessionState(user) {
     this.setState({
-      authenticated: account !== undefined,
-      account: account
+      authenticated: user !== undefined,
+      user: user
     });
   }
 
   componentDidMount() {
-    this._setAccountState(context.sessionStore.get());
-    context.sessionStore.addListener('changed', this.accountChangeListener);
+    this._setSessionState(context.sessionStore.get());
+    context.sessionStore.addListener('changed', this.sessionChangeListener);
   }
 
   componentWillUnmount() {
-    context.sessionStore.removeListener('changed', this.accountChangeListener);
+    context.sessionStore.removeListener('changed', this.sessionChangeListener);
   }
 
   getChildContext() {
     return {
       authenticated: this.state.authenticated,
-      account: this.state.account
+      user: this.state.user
     };
   }
 }

--- a/src/components/UserComponent.js
+++ b/src/components/UserComponent.js
@@ -4,6 +4,11 @@ import UserStore from '../stores/UserStore';
 export default class UserComponent extends React.Component {
   onChangeListener = null;
 
+  constructor() {
+    super(...arguments);
+    console.error('Stormpath SDK: Warning! The UserComponent class has been deprecated. Please use the account context instead. See: https://github.com/stormpath/stormpath-sdk-react/blob/master/docs/api.md#contexts');
+  }
+
   state = {
     user: {}
   };

--- a/src/components/UserComponent.js
+++ b/src/components/UserComponent.js
@@ -6,7 +6,7 @@ export default class UserComponent extends React.Component {
 
   constructor() {
     super(...arguments);
-    console.error('Stormpath SDK: Warning! The UserComponent class has been deprecated. Please use the account context instead. See: https://github.com/stormpath/stormpath-sdk-react/blob/master/docs/api.md#contexts');
+    console.error('Stormpath SDK: Warning! The UserComponent class has been deprecated. Please use the user context instead. See: https://github.com/stormpath/stormpath-sdk-react/blob/master/docs/api.md#contexts');
   }
 
   state = {

--- a/src/components/UserField.js
+++ b/src/components/UserField.js
@@ -4,7 +4,7 @@ import UserComponent from './UserComponent';
 export default class UserField extends UserComponent {
   constructor() {
     super(...arguments);
-    console.error('Stormpath SDK: Warning! The UserField component has been deprecated. Please use the account context instead. See: https://github.com/stormpath/stormpath-sdk-react/blob/master/docs/api.md#contexts');
+    console.error('Stormpath SDK: Warning! The UserField component has been deprecated. Please use the user context instead. See: https://github.com/stormpath/stormpath-sdk-react/blob/master/docs/api.md#contexts');
   }
 
   _resolveFieldValue(name) {

--- a/src/components/UserField.js
+++ b/src/components/UserField.js
@@ -1,10 +1,10 @@
 import React from 'react';
-
 import UserComponent from './UserComponent';
 
 export default class UserField extends UserComponent {
   constructor() {
     super(...arguments);
+    console.error('Stormpath SDK: Warning! The UserField component has been deprecated. Please use the account context instead. See: https://github.com/stormpath/stormpath-sdk-react/blob/master/docs/api.md#contexts');
   }
 
   _resolveFieldValue(name) {

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 import app from './app';
 
-export Context from './Context';
+export context from './context';
 export Router from './components/Router';
 
 export actions from './actions/UserActions';

--- a/src/stores/BaseStore.js
+++ b/src/stores/BaseStore.js
@@ -1,15 +1,15 @@
 var EventEmitter = require('events').EventEmitter;
 
 export default class BaseStore extends EventEmitter {
-  emitChange() {
-    this.emit('change');
+  emitChange(value) {
+    this.emit('changed', value);
   }
 
   addChangeListener(callback) {
-    return this.on('change', callback);
+    return this.on('changed', callback);
   }
 
   removeChangeListener(callback) {
-    this.removeListener('change', callback);
+    this.removeListener('changed', callback);
   }
 }

--- a/src/stores/SessionStore.js
+++ b/src/stores/SessionStore.js
@@ -1,0 +1,27 @@
+import BaseStore from './BaseStore';
+
+export default class SessionStore extends BaseStore {
+  session = undefined;
+
+  get() {
+    return this.session;
+  }
+
+  set(session) {
+    if (this.session !== session) {
+      this.session = session;
+      this.emitChange(session);
+    }
+  }
+
+  empty() {
+    return this.session === undefined;
+  }
+
+  reset() {
+    if (this.session !== undefined) {
+      this.session = undefined;
+      this.emitChange(undefined);
+    }
+  }
+}

--- a/src/stores/UserStore.js
+++ b/src/stores/UserStore.js
@@ -4,14 +4,13 @@ import BaseStore from '../stores/BaseStore';
 import UserService from '../services/UserService';
 import UserConstants from '../constants/UserConstants';
 
-var _session = false;
-var _sessionError = null;
-var _sessionResolved = false;
-
 class UserStore extends BaseStore {
   constructor() {
     super();
     this.service = null;
+    this.session = false;
+    this.sessionError = null;
+    this.sessionResolved = false;
   }
 
   init(context) {
@@ -20,12 +19,12 @@ class UserStore extends BaseStore {
   }
 
   getSession() {
-    return _session;
+    return this.session;
   }
 
   isAuthenticated(callback) {
     this.resolveSession((err, result) => {
-      callback(err, !err && _session !== false);
+      callback(err, !err && this.session !== false);
     });
   }
 
@@ -79,33 +78,33 @@ class UserStore extends BaseStore {
   }
 
   resolveSession(callback) {
-    if (_sessionResolved) {
-      return callback && callback(_sessionError, _session);
+    if (this.sessionResolved) {
+      return callback && callback(this.sessionError, this.session);
     }
 
     this.service.me((err, result) => {
       this.reset();
 
-      _sessionResolved = true;
+      this.sessionResolved = true;
 
       if (err) {
-        _sessionError = err;
+        this.sessionError = err;
       } else {
-        _session = result;
+        this.session = result;
       }
 
       if (callback) {
-        callback(_sessionError, _session);
+        callback(this.sessionError, this.session);
       }
 
       this.emitChange();
     });
   }
 
-  reset(resolved) {
-    _session = false;
-    _sessionError = null;
-    _sessionResolved = false;
+  reset() {
+    this.session = false;
+    this.sessionError = null;
+    this.sessionResolved = false;
   }
 }
 


### PR DESCRIPTION
Adds support for emitting `account` and `authenticated` contexts from the Router.
##### Note

I have deprecated the UserComponent and UserField, since those are no longer needed when we have the `account` context.
##### How to verify
1. Checkout this branch.
2. Build it (`$ npm run build`).
3. Link it (`$ npm link`).
4. Checkout the [the React example app](https://github.com/stormpath/stormpath-express-react-example).
5. Link to our React SDK feature branch (`$ npm link react-stormpath`).
6. Open up `src/pages/ProfilePage.js`.
7. Edit the page to look import the `account` context (as shown in [this gist](https://gist.github.com/typerandom/952df5ab61cbb3094c0e#file-stormpath-react-sdk-profile-page-with-account-context-js-L5-L14)).
8. Start the app (`$ npm start`).
9. Navigate to `/login`.
10. Verify that you were navigated to `/profile` (the page we modified) and that the field values are shown.
11. Add a `console.log(this.context.account);` in the `render()` method of the `ProfilePage` and verify that the account is written to console.
12. Login and logout, and verify that the account is `undefined` when logged out, and an account object when logged in.
13. Do steps 11-12 but for the [`authenticated` context](https://github.com/stormpath/stormpath-sdk-react/blob/feature-context-support/docs/api.md#authenticated-bool).
##### Documentation

See: https://github.com/stormpath/stormpath-sdk-react/blob/feature-context-support/docs/api.md#contexts

Fixes #1.
