### PR TITLE
Add Social Login support

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -369,12 +369,12 @@ app.post('/me', bodyParser.json(), stormpath.loginRequired, function (req, res) 
     res.json({ message: message, status: 400 });
     res.end();
   }
-  
+
   function saveAccount() {
     req.user.givenName = req.body.givenName;
     req.user.surname = req.body.surname;
     req.user.email = req.body.email;
-    
+
     req.user.save(function (err) {
       if (err) {
         return writeError(err.userMessage || err.message);
@@ -385,7 +385,7 @@ app.post('/me', bodyParser.json(), stormpath.loginRequired, function (req, res) 
 
   if (req.body.password) {
     var application = req.app.get('stormpathApplication');
-    
+
     application.authenticateAccount({
       username: req.user.username,
       password: req.body.existingPassword
@@ -393,9 +393,9 @@ app.post('/me', bodyParser.json(), stormpath.loginRequired, function (req, res) 
       if (err) {
         return writeError('The existing password that you entered was incorrect.');
       }
-      
+
       req.user.password = req.body.password();
-      
+
       saveAccount();
     });
   } else {
@@ -474,6 +474,52 @@ Renders a link that points to the LoginRoute or `/login` if no LoginRoute is spe
 <LoginLink />
 <LoginLink><img src="wrap-something-in-a-login-link.png" /></LoginLink>
 ```
+
+#### SocialLoginLink
+
+Renders a link that can be used to sign in with a social provider.
+
+```html
+<SocialLoginLink providerId='facebook' />
+<SocialLoginLink providerId='facebook'>Sign in with Facebook</SocialLoginLink>
+```
+
+Renders a link that can be used to sign into a social provider.
+
+```html
+<SocialLoginLink providerId='facebook' />
+```
+
+Set specific scopes by providing the `scope` option.
+
+```html
+<SocialLoginLink providerId='facebook' scope='email user_friends' />
+```
+
+Set your own redirect URI by providing the `redirectUri` option. If this isn't set then it defaults to `[protocol]://[host]/callbacks/[providerId]`.
+
+```html
+<SocialLoginLink providerId='facebook' redirectUri='http://www.my-domain.com/callbacks/facebook' />
+```
+
+#### SocialLoginButton
+
+Renders a button that can be used to sign in with a social provider.
+
+```html
+<SocialLoginButton providerId='facebook' />
+<SocialLoginButton providerId='facebook'>Sign in with Facebook</SocialLoginButton>
+```
+
+If you don't want the button to show an icon, then simply disable it by setting the `hideIcon` option.
+
+```html
+<SocialLoginButton providerId='facebook' hideIcon={ true } />
+```
+
+**Note:** The same options that are supported by the `SocialLoginLink` component are also supported by this.
+
+**Important:** This component relies on [Font Awesome](http://fortawesome.github.io/Font-Awesome/) in order to render icons for the various social providers. So if you want to use this button with icons, you also need to install Font Awesome on your site.
 
 #### LogoutLink
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -172,6 +172,12 @@ Specify `redirectTo` to set the path to redirect to after logging in. If this is
 <LoginForm redirectTo='/pathToRedirectTo' />
 ```
 
+Specify `hideSocial` to hide the ability to sign in with a social provider.
+
+```html
+<LoginForm hideSocial={true} />
+```
+
 Customize the form by providing your own markup.
 
 ```html
@@ -231,6 +237,12 @@ Specify `redirectTo` to set the path to redirect to after registering.  If this 
 
 ```html
 <RegistrationForm redirectTo='/pathToRedirectTo' />
+```
+
+Specify `hideSocial` to hide the ability to register with a social provider.
+
+```html
+<RegistrationForm hideSocial={true} />
 ```
 
 Customize the form by providing your own markup.
@@ -484,7 +496,7 @@ Renders a link that can be used to sign in with a social provider.
 <SocialLoginLink providerId='facebook'>Sign in with Facebook</SocialLoginLink>
 ```
 
-Renders a link that can be used to sign into a social provider.
+Renders a link that can be used to sign in using a social provider.
 
 ```html
 <SocialLoginLink providerId='facebook' />
@@ -499,7 +511,7 @@ Set specific scopes by providing the `scope` option.
 Set your own redirect URI by providing the `redirectUri` option. If this isn't set then it defaults to `[protocol]://[host]/callbacks/[providerId]`.
 
 ```html
-<SocialLoginLink providerId='facebook' redirectUri='http://www.my-domain.com/callbacks/facebook' />
+<SocialLoginLink providerId='facebook' redirectUri='http://www.example.com/callbacks/facebook' />
 ```
 
 #### SocialLoginButton

--- a/src/components/LoginForm.js
+++ b/src/components/LoginForm.js
@@ -43,7 +43,7 @@ class DefaultLoginForm extends React.Component {
 
       if (data && data.form) {
         fields = data.form.fields;
-        if (!this.props.hideSocialLogin) {
+        if (!this.props.hideSocial) {
           data.accountStores.forEach((accountStore) => {
             if (!accountStore.provider) {
               return;

--- a/src/components/LoginForm.js
+++ b/src/components/LoginForm.js
@@ -8,10 +8,12 @@ import context from '../context';
 import UserStore from '../stores/UserStore';
 import UserActions from '../actions/UserActions';
 import LoadingText from '../components/LoadingText';
+import SocialLoginButton from '../components/SocialLoginButton';
 
 class DefaultLoginForm extends React.Component {
   state = {
-    fields: null
+    fields: null,
+    socialProviders: null
   };
 
   componentDidMount() {
@@ -36,8 +38,31 @@ class DefaultLoginForm extends React.Component {
     ];
 
     UserStore.getLoginViewData((err, data) => {
+      var fields = null;
+      var socialProviders = null;
+
+      if (data && data.form) {
+        fields = data.form.fields;
+        if (!this.props.hideSocialLogin) {
+          data.accountStores.forEach((accountStore) => {
+            if (!accountStore.provider) {
+              return;
+            }
+
+            if (socialProviders === null) {
+              socialProviders = [];
+            }
+
+            socialProviders.push({
+              id: accountStore.provider.providerId
+            });
+          });
+        }
+      }
+
       this.setState({
-        fields: data && data.form ? data.form.fields : defaultFields
+        fields: fields,
+        socialProviders: socialProviders
       });
     });
   }
@@ -69,6 +94,31 @@ class DefaultLoginForm extends React.Component {
           </div>
         </div>
       );
+    }
+
+    if (this.state.socialProviders !== null) {
+      var providerButtons = [];
+
+      this.state.socialProviders.forEach((provider, index) => {
+        var providerKey = `sp-${provider.id}-${index}`;
+
+        providerButtons.push(
+          <SocialLoginButton key={ providerKey } providerId={ provider.id } style={{ marginRight: '5px', marginBottom: '5px' }} />
+        );
+      });
+
+      if (providerButtons.length) {
+        fieldMarkup.push(
+          <div key="provider-buttons" className="form-group" style={{ paddingTop: '20px' }}>
+            <div className="col-sm-offset-4 col-sm-4" style={{ marginBottom: '10px' }}>
+              Or sign in using...
+            </div>
+            <div className="col-sm-offset-4 col-sm-4">
+              { providerButtons }
+            </div>
+          </div>
+        );
+      }
     }
 
     return (

--- a/src/components/RegistrationForm.js
+++ b/src/components/RegistrationForm.js
@@ -61,7 +61,7 @@ class DefaultRegistrationForm extends React.Component {
 
       if (data && data.form) {
         fields = data.form.fields;
-        if (!this.props.hideSocialLogin) {
+        if (!this.props.hideSocial) {
           data.accountStores.forEach((accountStore) => {
             if (!accountStore.provider) {
               return;

--- a/src/components/RegistrationForm.js
+++ b/src/components/RegistrationForm.js
@@ -9,10 +9,12 @@ import LoginLink from '../components/LoginLink';
 import UserStore from '../stores/UserStore';
 import UserActions from '../actions/UserActions';
 import LoadingText from '../components/LoadingText';
+import SocialLoginButton from '../components/SocialLoginButton';
 
 class DefaultRegistrationForm extends React.Component {
   state = {
-    fields: null
+    fields: null,
+    socialProviders: null
   };
 
   componentDidMount() {
@@ -51,9 +53,34 @@ class DefaultRegistrationForm extends React.Component {
       }
     ];
 
+
+
     UserStore.getRegisterViewData((err, data) => {
+      var fields = null;
+      var socialProviders = null;
+
+      if (data && data.form) {
+        fields = data.form.fields;
+        if (!this.props.hideSocialLogin) {
+          data.accountStores.forEach((accountStore) => {
+            if (!accountStore.provider) {
+              return;
+            }
+
+            if (socialProviders === null) {
+              socialProviders = [];
+            }
+
+            socialProviders.push({
+              id: accountStore.provider.providerId
+            });
+          });
+        }
+      }
+
       this.setState({
-        fields: data && data.form ? data.form.fields : defaultFields
+        fields: fields,
+        socialProviders: socialProviders
       });
     });
   }
@@ -84,6 +111,31 @@ class DefaultRegistrationForm extends React.Component {
           </div>
         </div>
       );
+    }
+
+    if (this.state.socialProviders !== null) {
+      var providerButtons = [];
+
+      this.state.socialProviders.forEach((provider, index) => {
+        var providerKey = `sp-${provider.id}-${index}`;
+
+        providerButtons.push(
+          <SocialLoginButton key={ providerKey } providerId={ provider.id } style={{ marginRight: '5px', marginBottom: '5px' }} />
+        );
+      });
+
+      if (providerButtons.length) {
+        fieldMarkup.push(
+          <div key="provider-buttons" className="form-group" style={{ paddingTop: '20px' }}>
+            <div className="col-sm-offset-4 col-sm-4" style={{ marginBottom: '10px' }}>
+              Or register using...
+            </div>
+            <div className="col-sm-offset-4 col-sm-4">
+              { providerButtons }
+            </div>
+          </div>
+        );
+      }
     }
 
     return (

--- a/src/components/SocialLoginButton.js
+++ b/src/components/SocialLoginButton.js
@@ -1,0 +1,17 @@
+import React from 'react';
+
+import utils from '../utils';
+import SocialLoginLink from './SocialLoginLink';
+
+export default class SocialLoginButton extends React.Component {
+  render() {
+    var providerId = this.props.providerId;
+
+    return (
+      <SocialLoginLink {...this.props} className={ 'btn btn-default btn-social btn-' + providerId }>
+        { !this.props.hideIcon ? <span className={ 'fa fa-' + providerId } style={{ marginRight: '5px' }}></span> : null }
+        { this.props.children ? this.props.children : utils.translateProviderIdToName(providerId) }
+      </SocialLoginLink>
+    );
+  }
+}

--- a/src/components/SocialLoginLink.js
+++ b/src/components/SocialLoginLink.js
@@ -1,0 +1,96 @@
+import React from 'react';
+
+import utils from '../utils';
+import UserStore from './../stores/UserStore';
+
+let providerAuthorizationUris = {
+  github: 'https://github.com/login/oauth/authorize',
+  google: 'https://accounts.google.com/o/oauth2/v2/auth',
+  linkedin: 'https://www.linkedin.com/uas/oauth2/authorization',
+  facebook: 'https://www.facebook.com/dialog/oauth'
+};
+
+export default class SocialLoginLink extends React.Component {
+  state = {
+    disabled: false
+  };
+
+  _buildRedirectUri(provider) {
+    return location.protocol + '//' + location.host + '/callbacks/' + provider.providerId;
+  }
+
+  _createStateCookie() {
+    var stateId = utils.uuid();
+
+    document.cookie = 'oauthStateToken=' + stateId;
+
+    return stateId;
+  }
+
+  _buildAuthorizationUri(provider, scope, redirectUri) {
+    var authorizationUri = providerAuthorizationUris[provider.providerId];
+
+    if (!authorizationUri) {
+      return false;
+    }
+
+    var queryString = {
+      client_id: provider.clientId,
+      scope: scope || provider.scope,
+      redirect_uri: redirectUri || this._buildRedirectUri(provider),
+      state: this._createStateCookie(),
+      response_type: 'code'
+    };
+
+    return authorizationUri + '?' + utils.encodeQueryString(queryString);
+  }
+
+  _findProvider(accountStores, providerId) {
+    var provider;
+
+    for (var i = 0; i < accountStores.length; i++) {
+      var item = accountStores[i];
+
+      if (item.provider.providerId === providerId) {
+        provider = item.provider;
+        break;
+      }
+    }
+
+    return provider;
+  }
+
+  _onClick(e) {
+    e.preventDefault();
+
+    if (!this.state.disabled) {
+      this.setState({ disabled: true });
+
+      var providerId = this.props.providerId;
+
+      UserStore.getLoginViewData((err, result) => {
+        if (err) {
+          return console.error('Error: Unable to retrieve login view data.');
+        }
+
+        var provider = this._findProvider(result.accountStores, providerId);
+
+        if (!provider) {
+          return console.error('Error: Unable to login. Social provider ' + utils.translateProviderIdToName(providerId) + ' not configured.');
+        }
+
+        window.location.href = this._buildAuthorizationUri(provider, this.props.scope, this.props.redirectTo);
+      });
+    }
+  }
+
+  render() {
+    var providerId = this.props.providerId;
+
+    return (
+      <a {...this.props} href='#' className={this.props.className} onClick={this._onClick.bind(this)} disabled={this.state.disabled}>
+        { this.props.children ? this.props.children : 'Login with ' + utils.translateProviderIdToName(providerId)}
+      </a>
+    );
+  }
+}

--- a/src/components/SocialLoginLink.js
+++ b/src/components/SocialLoginLink.js
@@ -88,7 +88,7 @@ export default class SocialLoginLink extends React.Component {
     var providerId = this.props.providerId;
 
     return (
-      <a {...this.props} href='#' className={this.props.className} onClick={this._onClick.bind(this)} disabled={this.state.disabled}>
+      <a {...this.props} href='#' onClick={this._onClick.bind(this)} disabled={this.state.disabled}>
         { this.props.children ? this.props.children : 'Login with ' + utils.translateProviderIdToName(providerId)}
       </a>
     );

--- a/src/index.js
+++ b/src/index.js
@@ -23,6 +23,9 @@ export RegistrationForm from './components/RegistrationForm';
 export ResetPasswordForm from './components/ResetPasswordForm';
 export VerifyEmailView from './components/VerifyEmailView';
 
+export SocialLoginLink from './components/SocialLoginLink';
+export SocialLoginButton from './components/SocialLoginButton';
+
 export UserField from './components/UserField';
 export UserComponent from './components/UserComponent';
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -4,6 +4,44 @@ import React from 'react';
 class Utils {
   nopElement = <span />;
 
+  uuid() {
+    var s4 = () => Math.floor((1 + Math.random()) * 0x10000)
+      .toString(16).substring(1);
+
+    return s4() + s4() + '-' + s4() + '-' + s4() + '-' +
+      s4() + '-' + s4() + s4() + s4();
+  }
+
+  translateProviderIdToName(providerId) {
+    var newName;
+
+    switch (providerId) {
+      case 'github':
+        newName = 'GitHub';
+        break;
+      case 'linkedin':
+        newName = 'LinkedIn';
+        break;
+      default:
+        newName = providerId[0].toUpperCase() + providerId.slice(1);
+    }
+
+    return newName;
+  }
+
+  encodeQueryString(query) {
+    var result = '';
+
+    for (var key in query) {
+      if (result !== '') {
+        result += '&';
+      }
+      result += key + '=' + encodeURIComponent(query[key]);
+    }
+
+    return result;
+  }
+
   deepForEach(node, handler) {
     handler(node);
     if (node.props.children) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -13,17 +13,15 @@ class Utils {
   }
 
   translateProviderIdToName(providerId) {
-    var newName;
+    var providerNames = {
+      github: 'GitHub',
+      linkedin: 'LinkedIn'
+    };
 
-    switch (providerId) {
-      case 'github':
-        newName = 'GitHub';
-        break;
-      case 'linkedin':
-        newName = 'LinkedIn';
-        break;
-      default:
-        newName = providerId[0].toUpperCase() + providerId.slice(1);
+    var newName = providerNames[providerId];
+
+    if (!newName) {
+      newName = providerId[0].toUpperCase() + providerId.slice(1);
     }
 
     return newName;


### PR DESCRIPTION
Add support for social login with the `SocialLoginLink` and `SocialLoginButton` components.
#### Note

This depends on https://github.com/stormpath/express-stormpath/pull/374 in order for Facebook to be supported.
#### How to verify
1. Checkout this branch.
2. Build it (`$ npm run build`).
3. Link it (`$ npm link`).
4. Checkout the `social-login` branch of [the React example app](https://github.com/stormpath/stormpath-express-react-example/tree/social-login).
5. Link to our React SDK feature branch (`$ npm link react-stormpath`).
6. Log into the [Stormpath Console](https://api.stormpath.com/) and configure/map the Facebook, Google, Github and LinkedIn social provider directories for your application.
7. Start the application (`$ npm start`).
8. Navigate to `/login`.
9. Verify that all of the mapped social providers are visible below a box called `Or login with...`.
10. Click each provider and verify that you can login with them. Note that for Facebook, you need to patch the example application with [the branch of this express-stormpath PR](https://github.com/stormpath/express-stormpath/pull/374). Or else it won't work.
11. Login to the Stormpath Console, and unmap one provider at a time while restarting the app and verifying that they are removed from the `Or login with...` box.
12. When all providers are unmapped, verify that the `Or login with...` box disappears.
13. Using [the documentation](https://github.com/stormpath/stormpath-sdk-react/blob/feature-social-login/docs/api.md), open up the example application and manually add your own [`SocialLoginLink`](https://github.com/stormpath/stormpath-sdk-react/blob/feature-social-login/docs/api.md#socialloginlink) and [`SocialLoginButton`](https://github.com/stormpath/stormpath-sdk-react/blob/feature-social-login/docs/api.md#socialloginbutton).
14. Verify that the link/button works as expected.

Fixes #14.
