### PR TITLE
Add support for ChangePasswordForm

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -350,6 +350,68 @@ class ResetPasswordPage extends React.Component {
 }
 ```
 
+#### ChangePasswordForm
+
+Renders a change password form. The parameter `spToken` is required in order for the token to be validated.
+
+```html
+<ChangePasswordForm spToken={this.props.location.query.sptoken} />
+```
+
+Customize the form by providing your own markup.
+
+```html
+<ChangePasswordForm>
+  <div spIf="form.sent">
+    <p spIf="form.processing">We are verifying your change password request...</p>
+    <p spIf="form.success">Your new password has been set. Please <LoginLink />.</p>
+    <p spIf="form.error">The reset password token is not valid. Please try resetting your password again.</p>
+  </div>
+  <div spIf="!form.sent">
+    <p>
+      <label htmlFor="password">Password</label><br />
+      <input id="password" type="password" name="password" required />
+    </p>
+    <p>
+      <label htmlFor="confirmPassword">Password (again)</label><br />
+      <input id="confirmPassword" type="password" name="confirmPassword" required />
+    </p>
+    <p spIf="form.error">
+      <strong>Error:</strong><br />
+      <span spBind="form.errorMessage" />
+    </p>
+    <p>
+      <input type="submit" value="Change Password" />
+    </p>
+  </div>
+</ChangePasswordForm>
+```
+
+If you want to handle the form `onSubmit()` event, then simply provide a callback for it.
+
+```javascript
+class ChangePasswordPage extends React.Component {
+  onFormSubmit(e, next) {
+    // e.data will contain the data mapped from your form.
+    console.log("Form submitted", e.data);
+
+    // To return an error message, call next() as:
+    // next(new Error('Something in the form is wrong.'));
+
+    // Or if you want to change the data being sent, call it as:
+    // next(null, { myNewData: '123' });
+
+    // If you call next without any arguments,
+    // it will simply proceed processing the form.
+    next();
+  }
+
+  render() {
+    return <ChangePasswordForm onSubmit={this.onFormSubmit.bind(this)} />;
+  }
+}
+```
+
 #### UserProfileForm
 
 Renders a form that allows you to update the user profile.
@@ -369,12 +431,12 @@ app.post('/me', bodyParser.json(), stormpath.loginRequired, function (req, res) 
     res.json({ message: message, status: 400 });
     res.end();
   }
-  
+
   function saveAccount() {
     req.user.givenName = req.body.givenName;
     req.user.surname = req.body.surname;
     req.user.email = req.body.email;
-    
+
     req.user.save(function (err) {
       if (err) {
         return writeError(err.userMessage || err.message);
@@ -385,7 +447,7 @@ app.post('/me', bodyParser.json(), stormpath.loginRequired, function (req, res) 
 
   if (req.body.password) {
     var application = req.app.get('stormpathApplication');
-    
+
     application.authenticateAccount({
       username: req.user.username,
       password: req.body.existingPassword
@@ -393,9 +455,9 @@ app.post('/me', bodyParser.json(), stormpath.loginRequired, function (req, res) 
       if (err) {
         return writeError('The existing password that you entered was incorrect.');
       }
-      
+
       req.user.password = req.body.password();
-      
+
       saveAccount();
     });
   } else {

--- a/docs/api.md
+++ b/docs/api.md
@@ -363,9 +363,7 @@ Customize the form by providing your own markup.
 ```html
 <ChangePasswordForm>
   <div spIf="form.sent">
-    <p spIf="form.processing">We are verifying your change password request...</p>
-    <p spIf="form.success">Your new password has been set. Please <LoginLink />.</p>
-    <p spIf="form.error">The reset password token is not valid. Please try resetting your password again.</p>
+    <p>Your new password has been set. Please <LoginLink />.</p>
   </div>
   <div spIf="!form.sent">
     <p>

--- a/docs/api.md
+++ b/docs/api.md
@@ -361,7 +361,7 @@ Renders a change password form. The parameter `spToken` is required in order for
 Customize the form by providing your own markup.
 
 ```html
-<ChangePasswordForm>
+<ChangePasswordForm spToken={requiredSpToken}>
   <div spIf="form.sent">
     <p>Your new password has been set. Please <LoginLink />.</p>
   </div>
@@ -405,7 +405,7 @@ class ChangePasswordPage extends React.Component {
   }
 
   render() {
-    return <ChangePasswordForm onSubmit={this.onFormSubmit.bind(this)} />;
+    return <ChangePasswordForm spToken={requiredSpToken} onSubmit={this.onFormSubmit.bind(this)} />;
   }
 }
 ```

--- a/src/components/ChangePasswordForm.js
+++ b/src/components/ChangePasswordForm.js
@@ -53,8 +53,7 @@ export default class ChangePasswordForm extends React.Component {
   state = {
     spToken: null,
     fields: {
-      password: '',
-      confirmPassword: undefined
+      password: ''
     },
     errorMessage: null,
     isFormSent: false,
@@ -86,7 +85,7 @@ export default class ChangePasswordForm extends React.Component {
       // then simply default to what we have in state.
       data = data || this.state.fields;
 
-      if (data.confirmPassword !== undefined && data.password !== data.confirmPassword) {
+      if ('confirmPassword' in data && data.password !== data.confirmPassword) {
         return this.setState({
           isFormProcessing: false,
           errorMessage: 'Passwords does not match.'

--- a/src/components/ChangePasswordForm.js
+++ b/src/components/ChangePasswordForm.js
@@ -1,0 +1,186 @@
+import React from 'react';
+import ReactMixin from 'react-mixin';
+import { History, Link } from 'react-router';
+
+import utils from '../utils';
+import LoginLink from '../components/LoginLink';
+import LoadingText from '../components/LoadingText';
+import UserActions from '../actions/UserActions';
+
+class DefaultChangePasswordForm extends React.Component {
+  render() {
+    return (
+      <ChangePasswordForm {...this.props}>
+        <div className='sp-change-password-form'>
+          <div className="row" >
+            <div className="col-sm-offset-4 col-xs-12 col-sm-4" spIf="form.sent">
+              <p className="alert alert-warning text-center" spIf="form.processing">
+                We are verifying your change password request...
+              </p>
+              <p className="alert alert-success" spIf="form.success">Your new password has been set. Please <LoginLink />.</p>
+              <div className="alert alert-danger" spIf="form.error">
+                This password reset link is not valid.  You may request another link by <a href="/forgot">clicking here</a>.
+              </div>
+            </div>
+            <div className="col-xs-12" spIf="!form.sent">
+              <div className="form-horizontal">
+                <div className="form-group">
+                  <label htmlFor="spPassword" className="col-xs-12 col-sm-4 control-label">New Password</label>
+                  <div className="col-xs-12 col-sm-4">
+                    <input id="spPassword" type="password" name="password" className="form-control" placeholder="New Password" required />
+                  </div>
+                </div>
+                <div className="form-group">
+                  <label htmlFor="spConfirmPassword" className="col-xs-12 col-sm-4 control-label">Confirm New Password</label>
+                  <div className="col-xs-12 col-sm-4">
+                    <input id="spConfirmPassword" type="password" name="confirmPassword" className="form-control" placeholder="Confirm New Password" required />
+                  </div>
+                </div>
+                <div className="form-group">
+                  <div className="col-sm-offset-4 col-sm-4">
+                    <p className="alert alert-danger" spIf="form.error"><span spBind="form.errorMessage" /></p>
+                    <button type="submit" className="btn btn-primary">Set New Password</button>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </ChangePasswordForm>
+    );
+  }
+}
+
+@ReactMixin.decorate(History)
+export default class ChangePasswordForm extends React.Component {
+  state = {
+    spToken: null,
+    fields: {
+      password: '',
+      confirmPassword: ''
+    },
+    errorMessage: null,
+    isFormProcessing: false,
+    isFormSent: false
+  };
+
+  constructor(...args) {
+    super(...args);
+    this.state.spToken = this.props.spToken;
+  }
+
+  onFormSubmit(e) {
+    e.preventDefault();
+
+    var next = (err, data) => {
+      if (err) {
+        return this.setState({
+          isFormProcessing: false,
+          errorMessage: err.message
+        });
+      }
+
+      // If the user didn't specify any data,
+      // then simply default to what we have in state.
+      data = data || this.state.fields;
+
+      if (data.confirmPassword && data.password !== data.confirmPassword) {
+        return this.setState({
+          isFormProcessing: false,
+          errorMessage: 'Passwords does not match.'
+        });
+      }
+
+      this.setState({
+        isFormSent: true
+      });
+
+      UserActions.changePassword(this.state.fields, (err) => {
+        this.setState({
+          isFormProcessing: false,
+          errorMessage: err ? err.message : null
+        });
+      });
+    };
+
+    this.setState({
+      isFormSent: false,
+      isFormProcessing: true,
+      errorMessage: null
+    });
+
+    var data = this.state.fields;
+
+    if (this.state.spToken) {
+      data.sptoken = this.props.spToken;
+    }
+
+    if (this.props.onSubmit) {
+      e.data = data;
+      this.props.onSubmit(e, next);
+    } else {
+      next(null, data);
+    }
+  }
+
+  _mapFormFieldHandler(element, tryMapField) {
+    if (element.type === 'input' || element.type === 'textarea') {
+      if (element.props.type !== 'submit') {
+        switch(element.props.name) {
+          case 'password':
+            tryMapField('password');
+            break;
+          case 'confirmPassword':
+            tryMapField('confirmPassword');
+            break;
+        }
+      }
+    }
+  }
+
+  _spIfHandler(action, element) {
+    var test = null;
+
+    switch (action) {
+      case 'form.success':
+        test = this.state.isFormSent && !this.state.isFormProcessing && this.state.errorMessage === null;
+        break;
+      case 'form.processing':
+        test = this.state.isFormProcessing;
+        break;
+      case 'form.sent':
+        test = this.state.isFormSent;
+        break;
+      case 'form.error':
+        test = this.state.errorMessage !== null;
+        break;
+    }
+
+    return test;
+  }
+
+  _spBindHandler(bind, element) {
+    var result = false;
+
+    switch (bind) {
+      case 'form.errorMessage':
+        let className = element.props ? element.props.className : undefined;
+        result = <span className={className}>{this.state.errorMessage}</span>;
+        break;
+    }
+
+    return result;
+  }
+
+  render() {
+    if (this.props.children) {
+      return (
+        <form onSubmit={this.onFormSubmit.bind(this)}>
+          {utils.makeForm(this, this._mapFormFieldHandler.bind(this), this._spIfHandler.bind(this), this._spBindHandler.bind(this))}
+        </form>
+      );
+    } else {
+      return <DefaultChangePasswordForm {...this.props} />;
+    }
+  }
+}

--- a/src/components/ChangePasswordForm.js
+++ b/src/components/ChangePasswordForm.js
@@ -63,6 +63,11 @@ export default class ChangePasswordForm extends React.Component {
 
   constructor(...args) {
     super(...args);
+
+    if (!this.props || !('spToken' in this.props)) {
+      throw new Error('[Stormpath SDK/Error] ChangePasswordForm: Property \'spToken\' is required.');
+    }
+
     this.state.spToken = this.props.spToken;
   }
 

--- a/src/components/LoadingText.js
+++ b/src/components/LoadingText.js
@@ -25,7 +25,9 @@ export default class LoadingText extends React.Component {
     }
 
     return (
-      <p style={{ textAlign: 'center' }}>{ this.state.text }</p>
+      <p style={{ textAlign: 'center' }} classNames={ this.props.classNames }>
+        { this.props.children ? this.props.children : this.state.text }
+      </p>
     );
   }
 }

--- a/src/components/LoadingText.js
+++ b/src/components/LoadingText.js
@@ -25,7 +25,7 @@ export default class LoadingText extends React.Component {
     }
 
     return (
-      <p style={{ textAlign: 'center' }} classNames={ this.props.classNames }>
+      <p {...this.props} style={{ textAlign: 'center' }}>
         { this.props.children ? this.props.children : this.state.text }
       </p>
     );

--- a/src/components/VerifyEmailView.js
+++ b/src/components/VerifyEmailView.js
@@ -8,10 +8,6 @@ export default class VerifyEmailView extends React.Component {
     status: 'VERIFYING'
   };
 
-  constructor() {
-    super(...arguments);
-  }
-
   componentDidMount() {
     var spToken = this.props.spToken;
 

--- a/src/index.js
+++ b/src/index.js
@@ -21,6 +21,7 @@ export LoginForm from './components/LoginForm';
 export UserProfileForm from './components/UserProfileForm';
 export RegistrationForm from './components/RegistrationForm';
 export ResetPasswordForm from './components/ResetPasswordForm';
+export ChangePasswordForm from './components/ChangePasswordForm';
 export VerifyEmailView from './components/VerifyEmailView';
 
 export UserField from './components/UserField';

--- a/src/services/BaseService.js
+++ b/src/services/BaseService.js
@@ -75,7 +75,9 @@ export default class BaseService {
       if (result.status === 200) {
         callback(null, data);
       } else {
-        callback(new Error(data.message || data.error || 'A request to the API failed.'));
+        var error = new Error(data.message || data.error || 'A request to the API failed.');
+        error.status = result.status;
+        callback(error);
       }
     });
   }


### PR DESCRIPTION
Adds support for changing the password with the `ChangePasswordForm`.
#### How to verify
1. Checkout this branch.
2. Build it (`$ npm run build`).
3. Link it (`$ npm link`).
4. Checkout the branch `feature-change-password-form` of the [React example app](https://github.com/stormpath/stormpath-express-react-example/tree/feature-change-password-form).
5. Link to our React SDK feature branch (`$ npm link react-stormpath`).
6. Start the application (`$ npm start`).
7. Navigate to `http://localhost:3000/forgot`.
8. Reset the password for one of your existing accounts.
9. In the reset password email that you received, copy the value of the sptoken querystring for the reset password URL.
10. Navigate to `http://localhost:3000/forgot/change?sptoken=THE_SPTOKEN_VALUE_FROM_EMAIL_URL`.
11. Verify that the form works as expected.
12. Customize the form according to [the docs](https://github.com/stormpath/stormpath-sdk-react/blob/feature-change-password-form/docs/api.md#changepasswordform).
13. Verify that the form works as expected.

Fixes #49.
