### PR TITLE
fix custom redirectUri on SocialLoginLink

### DIFF
--- a/src/components/SocialLoginLink.js
+++ b/src/components/SocialLoginLink.js
@@ -79,7 +79,7 @@ export default class SocialLoginLink extends React.Component {
           return console.error('Error: Unable to login. Social provider ' + utils.translateProviderIdToName(providerId) + ' not configured.');
         }
 
-        window.location.href = this._buildAuthorizationUri(provider, this.props.scope, this.props.redirectTo);
+        window.location.href = this._buildAuthorizationUri(provider, this.props.scope, this.props.redirectUri);
       });
     }
   }


### PR DESCRIPTION
setting a custom callback URI doesn't work because the code is looking for this.props.redirectTo instead of this.props.redirectUri.  This patch fixes it, and addresses the github login problems I've been having.
