### PR TITLE
Fix enforceRootElement to wrap in a div instead of span

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -345,7 +345,7 @@ class Utils {
 
   enforceRootElement(object) {
     if (typeof object === 'string' || this.isArray(object)) {
-      object = <span>{ object }</span>;
+      object = <div style={{display: 'inline-block'}}>{ object }</div>;
     }
     return object;
   }


### PR DESCRIPTION
Fixes the enforceRootElement() utility function to wrap the element in a `<div>` instead of `<span>`-element.

Fixes #80
