### PR TITLE
Fix SyntheticEvent issue for form submit event

### DIFF
--- a/src/components/ChangePasswordForm.js
+++ b/src/components/ChangePasswordForm.js
@@ -70,6 +70,7 @@ export default class ChangePasswordForm extends React.Component {
 
   onFormSubmit(e) {
     e.preventDefault();
+    e.persist();
 
     var next = (err, data) => {
       if (err) {

--- a/src/components/LoginForm.js
+++ b/src/components/LoginForm.js
@@ -153,6 +153,7 @@ export default class LoginForm extends React.Component {
 
   onFormSubmit(e) {
     e.preventDefault();
+    e.persist();
 
     var next = (err, data) => {
       if (err) {

--- a/src/components/RegistrationForm.js
+++ b/src/components/RegistrationForm.js
@@ -185,6 +185,7 @@ export default class RegistrationForm extends React.Component {
 
   onFormSubmit(e) {
     e.preventDefault();
+    e.persist();
 
     var next = (err, data) => {
       if (err) {

--- a/src/components/ResetPasswordForm.js
+++ b/src/components/ResetPasswordForm.js
@@ -55,6 +55,7 @@ export default class ResetPasswordForm extends React.Component {
 
   onFormSubmit(e) {
     e.preventDefault();
+    e.persist();
 
     var next = (err, data) => {
       if (err) {

--- a/src/components/UserProfileForm.js
+++ b/src/components/UserProfileForm.js
@@ -117,6 +117,7 @@ export default class UserProfileForm extends React.Component {
 
   _onFormSubmit(e) {
     e.preventDefault();
+    e.persist();
 
     var next = (err, data) => {
       if (err) {


### PR DESCRIPTION
Fixes the issue with the "Warning: This synthetic event is reused for performance reasons. If you're seeing this, you're adding a new property in the synthetic event object. The property is never released. See https://fb.me/react-event-pooling for more information." warning message.

Fixes #71
