### PR TITLE
Fix so that session is resolved from /me instead of /login

### DIFF
--- a/src/stores/UserStore.js
+++ b/src/stores/UserStore.js
@@ -39,17 +39,12 @@ export default class UserStore extends BaseStore {
   login(options, callback) {
     this.reset();
 
-    this.service.login(options, (err, result) => {
+    this.service.login(options, (err) => {
       if (err) {
         return callback(err);
       }
 
-      this.sessionError = null;
-      this.sessionStore.set(result);
-      UserActions.set(result);
-      this.emitChange();
-
-      callback(null, result);
+      this.resolveSession(callback, true);
     });
   }
 


### PR DESCRIPTION
Fixes so that the session when logging in is resolved from the `/me` endpoint instead of the result of `/login`. This fixes the issue of expanded groups and custom data not being present at login because they are only expanded for the `/me` endpoint and not `/login`.
##### How to verify

Use the [example application](https://github.com/stormpath/stormpath-express-react-example) and do a regular email/password login, and verify that the `/me` endpoint is called when logging in.

Fixes #90.
