### PR TITLE
Added withCredentials = true to XmlHttpRequest

### DIFF
--- a/src/services/BaseService.js
+++ b/src/services/BaseService.js
@@ -12,6 +12,8 @@ function makeHttpRequest(method, uri, body, headers, callback) {
       request.setRequestHeader(name, value);
     }
   }
+  
+  request.withCredentials = true;
 
   request.onreadystatechange = function () {
     // 4 = Request finished and response is ready.


### PR DESCRIPTION
I noticed that you could make CORS requests with stormpath-sdk-angularjs because [it used XMLHttpRequests with "withCredentials" set to true](https://github.com/stormpath/stormpath-sdk-angularjs/blob/44f7c565bfd42c8a07b7717dca3836905c987436/CHANGELOG.md#new-features). After banging my head against the keyboard when dealing with the React version, I searched the repo and I didn't see any instance of that flag set.

I went ahead and added it to the BaseService after testing it in a local version (basically dove into node_modules/react-stormpath and added it there).
