### PR TITLE
Fix: Set withCredentials if the requested domain differs from the one we'r…

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -24,10 +24,13 @@ ReactStormpath.init({
     store: yourReduxStore
   },
 
-  // Optional: Set if you want to to use another API endpoint.
-  // Values shown below are the defaults.
+  // Optional endpoint configuration, if your are running our
+  // framework integration (e.g. express-stormpath) on a different
+  // domain, or you have changed the default endpoints in the
+  // framework integration. Values shown are the defaults.
+
   endpoints: {
-    baseUri: null,
+    baseUri: null,   // E.g. https://api.example.com
     me: '/me',
     login: '/login',
     register: '/register',

--- a/docs/api.md
+++ b/docs/api.md
@@ -24,13 +24,12 @@ ReactStormpath.init({
     store: yourReduxStore
   },
 
-  // Optional endpoint configuration, if your are running our
-  // framework integration (e.g. express-stormpath) on a different
-  // domain, or you have changed the default endpoints in the
-  // framework integration. Values shown are the defaults.
-
+  // Optional: If your are running our framework integration
+  // (e.g. express-stormpath) on a different domain, or you have
+  // changed the default endpoints in the framework integration.
+  // Values shown are the defaults.
   endpoints: {
-    baseUri: null,   // E.g. https://api.example.com
+    baseUri: null, // E.g. https://api.example.com
     me: '/me',
     login: '/login',
     register: '/register',

--- a/src/services/BaseService.js
+++ b/src/services/BaseService.js
@@ -13,6 +13,12 @@ function makeHttpRequest(method, uri, body, headers, callback) {
     }
   }
 
+  // If the URI is different than the URI of the domain we're on,
+  // then set withCredentials to true so that we enable CORS.
+  if (!utils.isRelativeUri(uri) && !utils.isSameHost(uri, window.location.href)) {
+    request.withCredentials = true;
+  }
+
   request.onreadystatechange = function () {
     // 4 = Request finished and response is ready.
     // Ignore everything else.
@@ -54,7 +60,6 @@ export default class BaseService {
 
   _makeRequest(method, path, body, callback) {
     var uri = this._buildEndpoint(path);
-
     var headers = {
       'Accept': 'application/json'
     };


### PR DESCRIPTION
Adds support for CORS requests by automatically setting withCredentials if the requested domain differs than the one we're on.
#### How to verify
1. Checkout the [React example application](https://github.com/stormpath/stormpath-express-react-example).
2. Checkout this branch.
3. Open up `BaseService.js` and after line 18 (inside the CORS condition), add `console.log('Setting request.withCredentials = true');`.
4. Run `$ npm run build-cjs`.
5. Link the example application to the checked out branch.
6. Start the application (`$ npm start`) and open your browser and navigate to `http://localhost:3000/`.
7. Open the console and verify that the example application works as expected (that you can login, etc). Without `Setting request.withCredentials = true` being present.
8. Open up `app.js` in the example application and change `ReactStormpath.init();` into `ReactStormpath.init({
   endpoints: {
     baseUri: 'http://other-domain.com'
   }
   });`.
9. Shut down the application and start it again (`$ npm start`).
10. Redo step 7. But instead of `Setting request.withCredentials = true` not being present in console, verify that it is and that network requests to `http://other-domain.com` are failing.

Closes #28
