### PR TITLE
Fix: Change the user-agent to have stormpath-sdk-react as a fixed name

### DIFF
--- a/src/services/BaseService.js
+++ b/src/services/BaseService.js
@@ -62,7 +62,7 @@ export default class BaseService {
     // Only set the X-Stormpath-Agent header if we're on the same domain as the requested URI.
     // This because we want to avoid CORS requests that require you to have to whitelist the X-Stormpath-Agent header.
     if (utils.isRelativeUri(uri) || utils.isSameHost(uri, window.location.href)) {
-      headers['X-Stormpath-Agent'] = `${pkg.name}/${pkg.version} react/${React.version}`;
+      headers['X-Stormpath-Agent'] = `stormpath-sdk-react/${pkg.version} react/${React.version}`;
     }
 
     makeHttpRequest(method, uri, body, headers, function (err, result) {


### PR DESCRIPTION
Changes the User-Agent from using the package name to `stormpath-sdk-react`.
#### How to verify

This is just a text edit, so not going to write anything comprehensive here.

But if you want to verify the change, use the [React example application](https://github.com/stormpath/stormpath-express-react-example) together with this branch, then during login, take a look at the requests and check that the `X-Stormpath-Agent` header is set and that the value starts with `stormpath-sdk-react` (previously `react-stormpath`).

Fixes #100 
