### PR TITLE
Fix: Always forward props from components to child elements

### DIFF
--- a/src/components/Authenticated.js
+++ b/src/components/Authenticated.js
@@ -1,5 +1,4 @@
 import React from 'react';
-
 import utils from '../utils';
 
 export default class Authenticated extends React.Component {
@@ -8,8 +7,8 @@ export default class Authenticated extends React.Component {
   };
 
   render() {
-    var user = this.context.user;
-    var authenticated = user !== undefined;
+    let user = this.context.user;
+    let authenticated = user !== undefined;
 
     if (authenticated && this.props.inGroup) {
       if (user.groups) {
@@ -19,6 +18,8 @@ export default class Authenticated extends React.Component {
       }
     }
 
-    return authenticated ? utils.enforceRootElement(this.props.children) : null;
+    let propsToForward = utils.excludeProps(['inGroup'], this.props);
+
+    return authenticated ? utils.enforceRootElement(this.props.children, propsToForward) : null;
   }
 }

--- a/src/components/ChangePasswordForm.js
+++ b/src/components/ChangePasswordForm.js
@@ -178,7 +178,7 @@ export default class ChangePasswordForm extends React.Component {
 
   render() {
     if (this.props.children) {
-      let selectedProps = utils.excludeProps(['onSubmit', 'children'], this.props);
+      let selectedProps = utils.excludeProps(['onSubmit', 'children', 'spToken'], this.props);
 
       return (
         <form onSubmit={this.onFormSubmit.bind(this)} {...selectedProps}>

--- a/src/components/ChangePasswordForm.js
+++ b/src/components/ChangePasswordForm.js
@@ -178,8 +178,10 @@ export default class ChangePasswordForm extends React.Component {
 
   render() {
     if (this.props.children) {
+      let selectedProps = utils.excludeProps(['onSubmit', 'children'], this.props);
+
       return (
-        <form onSubmit={this.onFormSubmit.bind(this)}>
+        <form onSubmit={this.onFormSubmit.bind(this)} {...selectedProps}>
           {utils.makeForm(this, this._mapFormFieldHandler.bind(this), this._spIfHandler.bind(this), this._spBindHandler.bind(this))}
         </form>
       );

--- a/src/components/NotAuthenticated.js
+++ b/src/components/NotAuthenticated.js
@@ -1,5 +1,4 @@
 import React from 'react';
-
 import utils from '../utils';
 
 export default class NotAuthenticated extends React.Component {
@@ -8,8 +7,8 @@ export default class NotAuthenticated extends React.Component {
   };
 
   render() {
-    var user = this.context.user;
-    var authenticated = user !== undefined;
+    let user = this.context.user;
+    let authenticated = user !== undefined;
 
     if (this.props.inGroup) {
       if (authenticated) {
@@ -23,6 +22,8 @@ export default class NotAuthenticated extends React.Component {
       }
     }
 
-    return !authenticated ? utils.enforceRootElement(this.props.children) : null;
+    let propsToForward = utils.excludeProps(['inGroup'], this.props);
+
+    return !authenticated ? utils.enforceRootElement(this.props.children, propsToForward) : null;
   }
 }

--- a/src/components/VerifyEmailView.js
+++ b/src/components/VerifyEmailView.js
@@ -1,5 +1,6 @@
 import React from 'react';
 
+import utils from '../utils';
 import LoginLink from '../components/LoginLink';
 import UserActions from '../actions/UserActions';
 
@@ -25,7 +26,7 @@ export default class VerifyEmailView extends React.Component {
   }
 
   render() {
-    let selectedProps = utils.excludeProps(['className'], this.props);
+    let selectedProps = utils.excludeProps(['className','spToken'], this.props);
 
     return (
       <div className={"row " + this.props.className} {...selectedProps}>

--- a/src/utils.js
+++ b/src/utils.js
@@ -368,11 +368,40 @@ class Utils {
     return nativeIsArray(object) || toString.call(object) === '[object Array]';
   }
 
-  enforceRootElement(object) {
+  enforceRootElement(object, props) {
+    let newObject = undefined;
+
     if (typeof object === 'string' || this.isArray(object)) {
-      object = <div style={{display: 'inline-block'}}>{ object }</div>;
+      if (!props) {
+        props = {};
+      }
+
+      if (!props.style) {
+        props.style = {};
+      }
+
+      props.style.display = 'inline-block';
+
+      newObject = <div {...props}>{ object }</div>;
+    } else {
+      let newProps = props;
+      let newChildren = [];
+
+      if (object.props) {
+        for (let key in object.props) {
+          let value = object.props[key];;
+          if (key === 'children') {
+            newChildren = value;
+          } else {
+            newProps[key] = value;
+          }
+        }
+      }
+
+      newObject = React.cloneElement(object, newProps, newChildren);
     }
-    return object;
+
+    return newObject;
   }
 }
 


### PR DESCRIPTION
Fixes so that props are always forwarded from components (`LoginForm`, `RegistrationForm`, `Authenticated`, aso) to child elements.
#### How to verify

Use this branch with the React example application.

Use the various components `LoginForm`, `RegistrationForm`, `Authenticated` and `NotAuthenticated` and set props such as `classNames` and `style` and verify that these are on the first underlying element.

E.g.

``` html
<Authenticated style={{backgroundColor: 'black'}}>
  I should be wrapped in an element and have a black background.
</Authenticated>
```

And:

``` html
<Authenticated style={{backgroundColor: 'black'}}>
  <div>
    I should not be wrapped in an element, but the wrapping `div` above should have the a black background.
  </div>
</Authenticated>
```

Fixes #86
