### PR TITLE
Fix: redirectTo should be unchanged after state change

### DIFF
--- a/src/components/LoginForm.js
+++ b/src/components/LoginForm.js
@@ -155,6 +155,8 @@ export default class LoginForm extends React.Component {
     e.preventDefault();
     e.persist();
 
+    let primaryRedirectTo = this.props.redirectTo;
+
     var next = (err, data) => {
       if (err) {
         return this.setState({
@@ -178,7 +180,7 @@ export default class LoginForm extends React.Component {
           });
         }
 
-        this._performRedirect();
+        this._performRedirect(primaryRedirectTo);
       });
     };
 
@@ -194,11 +196,11 @@ export default class LoginForm extends React.Component {
     }
   }
 
-  _performRedirect() {
+  _performRedirect(primaryRedirectTo) {
     var router = context.getRouter();
     var homeRoute = router.getHomeRoute();
     var authenticatedHomeRoute = router.getAuthenticatedHomeRoute();
-    var redirectTo = this.props.redirectTo || (authenticatedHomeRoute || {}).path || (homeRoute || {}).path || '/';
+    var redirectTo = primaryRedirectTo || (authenticatedHomeRoute || {}).path || (homeRoute || {}).path || '/';
 
     this.context.router.push(redirectTo);
   }
@@ -249,7 +251,7 @@ export default class LoginForm extends React.Component {
 
   render() {
     if (this.props.children) {
-      let selectedProps = utils.excludeProps(['onSubmit', 'children'], this.props);
+      let selectedProps = utils.excludeProps(['redirectTo', 'hideSocial', 'onSubmit', 'children'], this.props);
 
       return (
         <form onSubmit={this.onFormSubmit.bind(this)} {...selectedProps}>

--- a/src/components/LogoutLink.js
+++ b/src/components/LogoutLink.js
@@ -13,11 +13,11 @@ export default class LogoutLink extends React.Component {
     disabled: false
   };
 
-  _performRedirect() {
+  _performRedirect(primaryRedirectTo) {
     var router = context.getRouter();
     var homeRoute = router.getHomeRoute();
     var loginRoute = router.getLoginRoute();
-    var redirectTo = this.props.redirectTo || (homeRoute || {}).path || (loginRoute || {}).path || '/';
+    var redirectTo = primaryRedirectTo || (homeRoute || {}).path || (loginRoute || {}).path || '/';
 
     this.context.router.push(redirectTo);
   }
@@ -25,17 +25,19 @@ export default class LogoutLink extends React.Component {
   onClick(e) {
     e.preventDefault();
 
+    let primaryRedirectTo = this.props.redirectTo;
+
     if (!this.state.disabled) {
       this.setState({ disabled: true });
 
       UserActions.logout(() => {
-        this._performRedirect();
+        this._performRedirect(primaryRedirectTo);
       });
     }
   }
 
   render() {
-    var selectedProps = utils.excludeProps(['href', 'onClick', 'disabled', 'children'], this.props);
+    var selectedProps = utils.excludeProps(['redirectTo', 'href', 'onClick', 'disabled', 'children'], this.props);
 
   	return (
       <a href='#' onClick={this.onClick.bind(this)} disabled={this.state.disabled} {...selectedProps}>

--- a/src/components/RegistrationForm.js
+++ b/src/components/RegistrationForm.js
@@ -187,6 +187,8 @@ export default class RegistrationForm extends React.Component {
     e.preventDefault();
     e.persist();
 
+    let primaryRedirectTo = this.props.redirectTo;
+
     var next = (err, data) => {
       if (err) {
         return this.setState({
@@ -218,7 +220,7 @@ export default class RegistrationForm extends React.Component {
               });
             }
 
-            this._performRedirect();
+            this._performRedirect(primaryRedirectTo);
           });
         } else {
           this.setState({
@@ -242,11 +244,11 @@ export default class RegistrationForm extends React.Component {
     }
   }
 
-  _performRedirect() {
+  _performRedirect(primaryRedirectTo) {
     var router = context.getRouter();
     var homeRoute = router.getHomeRoute();
     var authenticatedHomeRoute = router.getAuthenticatedHomeRoute();
-    var redirectTo = this.props.redirectTo || (authenticatedHomeRoute || {}).path || (homeRoute || {}).path || '/';
+    var redirectTo = primaryRedirectTo || (authenticatedHomeRoute || {}).path || (homeRoute || {}).path || '/';
 
     this.context.router.push(redirectTo);
   }
@@ -314,7 +316,7 @@ export default class RegistrationForm extends React.Component {
 
   render() {
     if (this.props.children) {
-      var selectedProps = utils.excludeProps(['onSubmit', 'children'], this.props);
+      var selectedProps = utils.excludeProps(['redirectTo', 'hideSocial', 'onSubmit', 'children'], this.props);
 
       return (
         <form onSubmit={this.onFormSubmit.bind(this)} {...selectedProps}>


### PR DESCRIPTION
Fixes so that `redirectTo` remains unchanged even after state changed.
#### How to verify
1. Checkout this branch and build it `$ npm run build-cjs`.
2. Checkout branch `reproduce-redirect-to-race-condition` of the [React example application](https://github.com/stormpath/stormpath-express-react-example).
3. Start the example application (`$ npm start`) and open `http://localhost:3000/` in your browser.
4. Login with an existing user.
5. Click logout and verify that you are redirected to `http://localhost:3000/goodbye/$USERNAME`. Where `$USERNAME` is the username of your logged in user.

Fixes #102
