### PR TITLE
Fix: Support routes as property to Router

### DIFF
--- a/src/components/Router.js
+++ b/src/components/Router.js
@@ -43,16 +43,22 @@ export default class Router extends ReactRouter {
   constructor() {
     super(...arguments);
 
-    this._mapMarkedRoutes();
+    if (this.props.routes) {
+      // The reason we wrap in a div is because we just need to have a root element.
+      this._mapMarkedRoutes(<div>{this.props.routes}</div>);
+    } else {
+      this._mapMarkedRoutes(this);
+    }
+
     this.sessionChangeListener = this._setSessionState.bind(this);
 
     context.setRouter(this);
   }
 
-  _mapMarkedRoutes() {
-    var markedRoutes = this.markedRoutes;
+  _mapMarkedRoutes(routes) {
+    let markedRoutes = this.markedRoutes;
 
-    utils.deepForEach(this, (node, parent) => {
+    utils.deepForEach(routes, (node, parent) => {
       // Try and map the route node to a marked route.
       for (var routeName in markedRoutes) {
         var route = markedRoutes[routeName];


### PR DESCRIPTION
Fixes so that routes can be provided as a property to our extended Router.
#### How to verify
1. Checkout this branch and build it `$ npm run build-cjs`.
2. Checkout branch `reproduce-provide-routes-through-property` of the [React example application](https://github.com/stormpath/stormpath-express-react-example).
3. Start the example application (`$ npm start`) and open `http://localhost:3000/` in your browser.
4. Verify that you are able to modify the routes and that the application works as expected. If the routes wouldn't be mapped, it would render blank.

Closes #88 
