### PR TITLE
Fix: Login request should use login instead of username field

### DIFF
--- a/src/components/LoginForm.js
+++ b/src/components/LoginForm.js
@@ -168,7 +168,7 @@ export default class LoginForm extends React.Component {
       data = data || this.state.fields;
 
       UserActions.login({
-        username: data.username,
+        login: data.username,
         password: data.password
       }, (err, result) => {
         if (err) {

--- a/src/components/RegistrationForm.js
+++ b/src/components/RegistrationForm.js
@@ -207,7 +207,7 @@ export default class RegistrationForm extends React.Component {
           });
         } else if (result.status === 'ENABLED') {
           UserActions.login({
-            username: data.email || data.username,
+            login: data.email || data.username,
             password: data.password
           }, (err) => {
             if (err) {


### PR DESCRIPTION
Fixes so that the request to the `/login` endpoint uses the `login` field instead of the `username` field.
#### How to verify
1. Checkout this branch and build it `$ npm run build-cjs`.
2. Checkout the master branch of the [React example application](https://github.com/stormpath/stormpath-express-react-example).
3. Link the branches together.
4. Start the example application (`$ npm start`) and open `http://localhost:3000/` in your browser.
5. Open up the network tab and click `perserve log`.
6. Login with an existing user.
7. Check the POST request to `/login` and verify that it was sent with the fields `login` and `password` (according to spec https://github.com/stormpath/stormpath-framework-spec/blob/master/login.md#-post-body-format).

Fixes #107 
