### PR TITLE
Add support for custom field components in forms

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -244,6 +244,10 @@ Customize the form by providing your own markup.
 </LoginForm>
 ```
 
+**Important:** To use a custom field component the name of the component must contain one of these three words: `text`, `input` or `field`.
+The component must also support the properties `name` and `onChange`. The property `name` should represent the name of the field, and the
+`onChange` property a handler for the field's `onChange` event.
+
 If you want to handle the form `onSubmit()` event, then simply provide a callback for it.
 
 ```javascript
@@ -369,6 +373,10 @@ Set custom data fields by prefixing field names with `customData`.
 
 **Important:** If you use the Node SDK, then all custom data fields during registration must be white listed as shown in the section [Creating Custom Fields](http://docs.stormpath.com/nodejs/express/latest/registration.html#creating-custom-fields).
 
+**Important:** To use a custom field component the name of the component must contain one of these three words: `text`, `input` or `field`.
+The component must also support the properties `name` and `onChange`. The property `name` should represent the name of the field, and the
+`onChange` property a handler for the field's `onChange` event.
+
 If you want to handle the form `onSubmit()` event, then simply provide a callback for it.
 
 ```javascript
@@ -463,6 +471,10 @@ Customize the form by providing your own markup.
 </ResetPasswordForm>
 ```
 
+**Important:** To use a custom field component the name of the component must contain one of these three words: `text`, `input` or `field`.
+The component must also support the properties `name` and `onChange`. The property `name` should represent the name of the field, and the
+`onChange` property a handler for the field's `onChange` event.
+
 If you want to handle the form `onSubmit()` event, then simply provide a callback for it.
 
 ```javascript
@@ -522,6 +534,10 @@ Customize the form by providing your own markup.
   </div>
 </ChangePasswordForm>
 ```
+
+**Important:** To use a custom field component the name of the component must contain one of these three words: `text`, `input` or `field`.
+The component must also support the properties `name` and `onChange`. The property `name` should represent the name of the field, and the
+`onChange` property a handler for the field's `onChange` event.
 
 If you want to handle the form `onSubmit()` event, then simply provide a callback for it.
 
@@ -638,6 +654,10 @@ Access custom data fields by prefixing field names with `customData`.
 ```
 
 **Important:** Set the `web.me.expand.customData` config to `true` in order to have the custom data fields populated.
+
+**Important:** To use a custom field component the name of the component must contain one of these three words: `text`, `input` or `field`.
+The component must also support the properties `name` and `onChange`. The property `name` should represent the name of the field, and the
+`onChange` property a handler for the field's `onChange` event.
 
 If you want to handle the form `onSubmit()` event, then simply provide a callback for it.
 

--- a/src/components/ChangePasswordForm.js
+++ b/src/components/ChangePasswordForm.js
@@ -131,16 +131,24 @@ export default class ChangePasswordForm extends React.Component {
   }
 
   _mapFormFieldHandler(element, tryMapField) {
-    if (element.type === 'input' || element.type === 'textarea') {
+    let tryMapFormField = (name) => {
+      switch(name) {
+        case 'password':
+          tryMapField('password');
+          break;
+        case 'confirmPassword':
+          tryMapField('confirmPassword');
+          break;
+      }
+    };
+
+    if (typeof element.type === 'function' && utils.containsWord(element.type.name, ['input', 'field', 'text'])) {
+      if (element.props && element.props.name) {
+        tryMapFormField(element.props.name);
+      }
+    } else if (element.type === 'input' || element.type === 'textarea') {
       if (element.props.type !== 'submit') {
-        switch(element.props.name) {
-          case 'password':
-            tryMapField('password');
-            break;
-          case 'confirmPassword':
-            tryMapField('confirmPassword');
-            break;
-        }
+        tryMapFormField(element.props.name);
       }
     }
   }

--- a/src/components/LoginForm.js
+++ b/src/components/LoginForm.js
@@ -232,17 +232,25 @@ export default class LoginForm extends React.Component {
   }
 
   _mapFormFieldHandler(element, tryMapField) {
-    if (element.type === 'input' || element.type === 'textarea') {
+    let tryMapFormField = (name) => {
+      switch(element.props.name) {
+        case 'login':
+        case 'username':
+          tryMapField('username');
+          break;
+        case 'password':
+          tryMapField('password');
+          break;
+      }
+    };
+
+    if (typeof element.type === 'function' && utils.containsWord(element.type.name, ['input', 'field', 'text'])) {
+      if (element.props && element.props.name) {
+        tryMapFormField(element.props.name);
+      }
+    } else if (['input', 'textarea'].indexOf(element.type) > -1) {
       if (element.props.type !== 'submit') {
-        switch(element.props.name) {
-          case 'login':
-          case 'username':
-            tryMapField('username');
-            break;
-          case 'password':
-            tryMapField('password');
-            break;
-        }
+        tryMapFormField(element.props.name);
       }
     }
   }

--- a/src/components/RegistrationForm.js
+++ b/src/components/RegistrationForm.js
@@ -297,35 +297,41 @@ export default class RegistrationForm extends React.Component {
   }
 
   _mapFormFieldHandler(element, tryMapField) {
-    if (['input', 'textarea'].indexOf(element.type) > -1) {
+    let tryMapFormField = (name) => {
+      if (name.indexOf('customData.') === 0) {
+        tryMapField(name);
+        return;
+      }
+
+      switch(name) {
+        case 'email':
+          tryMapField('email');
+          break;
+        case 'login':
+        case 'username':
+          tryMapField('username');
+          break;
+        case 'givenName':
+        case 'firstName':
+          tryMapField('givenName');
+          break;
+        case 'surname':
+        case 'lastName':
+          tryMapField('surname');
+          break;
+        case 'password':
+          tryMapField('password');
+          break;
+      }
+    };
+
+    if (typeof element.type === 'function' && utils.containsWord(element.type.name, ['input', 'field', 'text'])) {
+      if (element.props && element.props.name) {
+        tryMapFormField(element.props.name);
+      }
+    } else if (['input', 'textarea'].indexOf(element.type) > -1) {
       if (element.props.type !== 'submit') {
-        let name = element.props.name;
-
-        if (name.indexOf('customData.') === 0) {
-          tryMapField(name);
-          return;
-        }
-
-        switch(name) {
-          case 'email':
-            tryMapField('email');
-            break;
-          case 'login':
-          case 'username':
-            tryMapField('username');
-            break;
-          case 'givenName':
-          case 'firstName':
-            tryMapField('givenName');
-            break;
-          case 'surname':
-          case 'lastName':
-            tryMapField('surname');
-            break;
-          case 'password':
-            tryMapField('password');
-            break;
-        }
+        tryMapFormField(element.props.name);
       }
     }
   }

--- a/src/components/ResetPasswordForm.js
+++ b/src/components/ResetPasswordForm.js
@@ -98,13 +98,21 @@ export default class ResetPasswordForm extends React.Component {
   }
 
   _mapFormFieldHandler(element, tryMapField) {
-    if (element.type === 'input' || element.type === 'textarea') {
+    let tryMapFormField = (name) => {
+      switch(name) {
+        case 'email':
+          tryMapField('email');
+          break;
+      }
+    };
+
+    if (typeof element.type === 'function' && utils.containsWord(element.type.name, ['input', 'field', 'text'])) {
+      if (element.props && element.props.name) {
+        tryMapFormField(element.props.name);
+      }
+    } else if (['input', 'textarea'].indexOf(element.type) > -1) {
       if (element.props.type !== 'submit') {
-        switch(element.props.name) {
-          case 'email':
-            tryMapField('email');
-            break;
-        }
+        tryMapFormField(element.props.name);
       }
     }
   }

--- a/src/components/UserProfileForm.js
+++ b/src/components/UserProfileForm.js
@@ -168,8 +168,11 @@ export default class UserProfileForm extends React.Component {
       utils.getFieldValue(this.state.defaultFields, element.props.name) :
       undefined;
 
-    // Only support input fields, to begin with.
-    if (element.type === 'input') {
+    if (typeof element.type === 'function' && utils.containsWord(element.type.name, ['input', 'field', 'text'])) {
+      if (element.props && element.props.name) {
+        tryMapField(element.props.name, defaultValue);
+      }
+    } else if (element.type === 'input') {
       if (element.props.type === 'submit') {
         return;
       }

--- a/src/utils.js
+++ b/src/utils.js
@@ -12,6 +12,19 @@ class Utils {
       s4() + '-' + s4() + s4() + s4();
   }
 
+  containsWord(testWord, words) {
+    testWord = testWord.toLowerCase();
+
+    for (let i = 0; i < words.length; i++) {
+      let word = words[i].toLowerCase();
+      if (testWord.indexOf(word) > -1) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
   takeProp(source, ...fields) {
     for (let i = 0; i < fields.length; i++) {
       let fieldName = fields[i];
@@ -137,15 +150,16 @@ class Utils {
     for (var key in fields) {
       var field = fields[key];
       var element = field.element;
+      var elementType = typeof element.type === 'function' ? element.type.name : element.type;
 
-      if (!(element.type in inverseMap)) {
-        inverseMap[element.type] = {};
+      if (!(elementType in inverseMap)) {
+        inverseMap[elementType] = {};
       }
 
       defaultValues[key] = field.defaultValue !== undefined ?
         field.defaultValue : (element.props.value || '');
 
-      inverseMap[element.type][element.props.name] = {
+      inverseMap[elementType][element.props.name] = {
         fieldName: key,
         field: element
       };
@@ -251,7 +265,7 @@ class Utils {
       var options = {};
 
       if (element.props) {
-        var elementType = element.type;
+        var elementType = typeof element.type === 'function' ? element.type.name : element.type;
         var elementAttributeName = element.props.name;
 
         if (elementType in fieldMap.inverse && elementAttributeName in fieldMap.inverse[elementType]) {


### PR DESCRIPTION
Adds support for using custom field components in forms.
#### How to verify
1. Checkout this branch and build it with `$ npm run build-cjs`.
2. Checkout the `reproduce-custom-field-error` branch of the [React example application](https://github.com/stormpath/stormpath-express-react-example).
3. Link the branches together.
4. Start the example application (`$ npm start`) and open `http://localhost:3000/` in your browser.
5. Navigate to `/register`.
6. Verify that the fields are mapped and that the form functions as expected.
7. Checkout the `master` branch of the [React example application](https://github.com/stormpath/stormpath-express-react-example).
8. Redo steps 5-6.

Fixes #85 
Fixes #77
