### PR TITLE
Fix so that SocialLoginLink supports onClick property

### DIFF
--- a/src/components/SocialLoginLink.js
+++ b/src/components/SocialLoginLink.js
@@ -66,11 +66,16 @@ export default class SocialLoginLink extends React.Component {
 
   _onClick(e) {
     e.preventDefault();
+    e.persist();
 
     if (!this.state.disabled) {
       this.setState({ disabled: true });
 
       var providerId = this.props.providerId;
+
+      if (this.props.onClick) {
+        this.props.onClick(e);
+      }
 
       context.userStore.getLoginViewData((err, result) => {
         if (err) {


### PR DESCRIPTION
Fixes so that the `SocialLoginLink` component supports the `onClick` event property.
#### How to verify

Use the `SocialLoginLink` and attach a `onClick` property as shown below:

``` html
onLoginLinkClick(e) {
  console.log('Social login link was clicked!');
}

<SocialLoginLink onClick={this.onLoginLinkClick.bind(this)} />
```

**Note:** Remember to set the `perserve log` in your developer tools console. If you don't set that, then the `console.log()` might be cleared when the browser navigates to the provider login page.

Fixes #123
