### PR TITLE
Fix forms breaking on IE

### DIFF
--- a/src/components/ChangePasswordForm.js
+++ b/src/components/ChangePasswordForm.js
@@ -142,15 +142,7 @@ export default class ChangePasswordForm extends React.Component {
       }
     };
 
-    if (utils.isInputLikeComponent(element)) {
-      if (element.props && element.props.name) {
-        tryMapFormField(element.props.name);
-      }
-    } else if (element.type === 'input' || element.type === 'textarea') {
-      if (element.props.type !== 'submit') {
-        tryMapFormField(element.props.name);
-      }
-    }
+    utils.mapFormField(element, tryMapFormField);
   }
 
   _spIfHandler(action, element) {

--- a/src/components/ChangePasswordForm.js
+++ b/src/components/ChangePasswordForm.js
@@ -142,7 +142,7 @@ export default class ChangePasswordForm extends React.Component {
       }
     };
 
-    if (typeof element.type === 'function' && utils.containsWord(element.type.name, ['input', 'field', 'text'])) {
+    if (utils.isInputLikeComponent(element)) {
       if (element.props && element.props.name) {
         tryMapFormField(element.props.name);
       }

--- a/src/components/LoginForm.js
+++ b/src/components/LoginForm.js
@@ -244,7 +244,7 @@ export default class LoginForm extends React.Component {
       }
     };
 
-    if (typeof element.type === 'function' && utils.containsWord(element.type.name, ['input', 'field', 'text'])) {
+    if (utils.isInputLikeComponent(element)) {
       if (element.props && element.props.name) {
         tryMapFormField(element.props.name);
       }

--- a/src/components/LoginForm.js
+++ b/src/components/LoginForm.js
@@ -244,15 +244,7 @@ export default class LoginForm extends React.Component {
       }
     };
 
-    if (utils.isInputLikeComponent(element)) {
-      if (element.props && element.props.name) {
-        tryMapFormField(element.props.name);
-      }
-    } else if (['input', 'textarea'].indexOf(element.type) > -1) {
-      if (element.props.type !== 'submit') {
-        tryMapFormField(element.props.name);
-      }
-    }
+    utils.mapFormField(element, tryMapFormField);
   }
 
   _spIfHandler(action, element) {

--- a/src/components/RegistrationForm.js
+++ b/src/components/RegistrationForm.js
@@ -325,15 +325,7 @@ export default class RegistrationForm extends React.Component {
       }
     };
 
-    if (utils.isInputLikeComponent(element)) {
-      if (element.props && element.props.name) {
-        tryMapFormField(element.props.name);
-      }
-    } else if (['input', 'textarea'].indexOf(element.type) > -1) {
-      if (element.props.type !== 'submit') {
-        tryMapFormField(element.props.name);
-      }
-    }
+    utils.mapFormField(element, tryMapFormField);
   }
 
   _spIfHandler(action, element) {

--- a/src/components/RegistrationForm.js
+++ b/src/components/RegistrationForm.js
@@ -325,7 +325,7 @@ export default class RegistrationForm extends React.Component {
       }
     };
 
-    if (typeof element.type === 'function' && utils.containsWord(element.type.name, ['input', 'field', 'text'])) {
+    if (utils.isInputLikeComponent(element)) {
       if (element.props && element.props.name) {
         tryMapFormField(element.props.name);
       }

--- a/src/components/ResetPasswordForm.js
+++ b/src/components/ResetPasswordForm.js
@@ -106,15 +106,7 @@ export default class ResetPasswordForm extends React.Component {
       }
     };
 
-    if (utils.isInputLikeComponent(element)) {
-      if (element.props && element.props.name) {
-        tryMapFormField(element.props.name);
-      }
-    } else if (['input', 'textarea'].indexOf(element.type) > -1) {
-      if (element.props.type !== 'submit') {
-        tryMapFormField(element.props.name);
-      }
-    }
+    utils.mapFormField(element, tryMapFormField);
   }
 
   _spIfHandler(action, element) {

--- a/src/components/ResetPasswordForm.js
+++ b/src/components/ResetPasswordForm.js
@@ -106,7 +106,7 @@ export default class ResetPasswordForm extends React.Component {
       }
     };
 
-    if (typeof element.type === 'function' && utils.containsWord(element.type.name, ['input', 'field', 'text'])) {
+    if (utils.isInputLikeComponent(element)) {
       if (element.props && element.props.name) {
         tryMapFormField(element.props.name);
       }

--- a/src/components/UserProfileForm.js
+++ b/src/components/UserProfileForm.js
@@ -168,7 +168,7 @@ export default class UserProfileForm extends React.Component {
       utils.getFieldValue(this.state.defaultFields, element.props.name) :
       undefined;
 
-    if (typeof element.type === 'function' && utils.containsWord(element.type.name, ['input', 'field', 'text'])) {
+    if (utils.isInputLikeComponent(element)) {
       if (element.props && element.props.name) {
         tryMapField(element.props.name, defaultValue);
       }

--- a/src/components/UserProfileForm.js
+++ b/src/components/UserProfileForm.js
@@ -168,17 +168,7 @@ export default class UserProfileForm extends React.Component {
       utils.getFieldValue(this.state.defaultFields, element.props.name) :
       undefined;
 
-    if (utils.isInputLikeComponent(element)) {
-      if (element.props && element.props.name) {
-        tryMapField(element.props.name, defaultValue);
-      }
-    } else if (element.type === 'input') {
-      if (element.props.type === 'submit') {
-        return;
-      }
-
-      tryMapField(element.props.name, defaultValue);
-    }
+    utils.mapFormField(element, tryMapField, defaultValue);
   }
 
   _spIfHandler(action, element) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -143,6 +143,18 @@ class Utils {
     return React.cloneElement(newElement, newOptions, newChildren);
   }
 
+  mapFormField(element, mappingFn, defaultValue) {
+    if (this.isInputLikeComponent(element)) {
+      if (element.props && element.props.name) {
+        mappingFn(element.props.name, defaultValue);
+      }
+    } else if (['input', 'textarea'].indexOf(element.type) > -1) {
+      if (element.props.type !== 'submit') {
+        mappingFn(element.props.name, defaultValue);
+      }
+    }
+  }
+
   getFormFieldMap(root, handler) {
     var fields = {};
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -13,6 +13,10 @@ class Utils {
   }
 
   containsWord(testWord, words) {
+    if (typeof testWord !== 'string') {
+      return false;
+    }
+
     testWord = testWord.toLowerCase();
 
     for (let i = 0; i < words.length; i++) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -12,6 +12,24 @@ class Utils {
       s4() + '-' + s4() + s4() + s4();
   }
 
+  functionName(f) {
+    if (typeof f !== 'function') {
+      return '';
+    }
+
+    if (f.name) {
+      return f.name;
+    }
+
+    const parts = f.toString().match(/^function\s*([^\s(]+)/);
+
+    if (parts) {
+      return parts[1];
+    }
+
+    return '';
+  }
+
   containsWord(testWord, words) {
     if (typeof testWord !== 'string') {
       return false;
@@ -27,6 +45,11 @@ class Utils {
     }
 
     return false;
+  }
+
+  isInputLikeComponent(element, inputNames = ['input', 'field', 'text']) {
+    return typeof element.type === 'function'
+      && this.containsWord(this.functionName(element.type), inputNames);
   }
 
   takeProp(source, ...fields) {


### PR DESCRIPTION
Fixes an issue where forms would break on IE if React components were included in them. Also contains some light refactoring.

@robertjd do note that this does not fix the minification problem, I'll need to talk to @typerandom about that bit of code first. However, it fixes the issue in #164 and should contain no changes for other browsers.

I would like to open a separate issue for rewriting that bit more robustly after I see what _exactly_ Robin was intending to do with the code.

Fixes #164 