### PR TITLE
Fix issue where callback was called twice on success

### DIFF
--- a/src/services/BaseService.js
+++ b/src/services/BaseService.js
@@ -71,13 +71,7 @@ function makeHttpRequest(method, uri, body, headers, callback) {
         result.responseJSON = JSON.parse(request.responseText);
       }
     } catch(e) {
-      caughtError = e;
-    }
-
-    if (caughtError) {
-      callback(caughtError);
-    } else {
-      callback(null, result);
+      return callback(e);
     }
 
     callback(null, result);


### PR DESCRIPTION
Fixes bug in `BaseService` where the passed callback was called twice on success.
Happened for *everything* based on `BaseService`.

Fixes #172 