### PR TITLE
Add support for PlainRoute format in router

### DIFF
--- a/src/components/Router.js
+++ b/src/components/Router.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Router as ReactRouter } from 'react-router';
+import { Router as ReactRouter, Route } from 'react-router';
 
 import utils from './../utils';
 import context from './../context';
@@ -14,6 +14,8 @@ export default class Router extends ReactRouter {
     authenticated: React.PropTypes.bool,
     user: React.PropTypes.object
   };
+
+  static propTypes = ReactRouter.propTypes;
 
   static defaultProps = ReactRouter.defaultProps;
 
@@ -46,8 +48,10 @@ export default class Router extends ReactRouter {
     super(...arguments);
 
     if (this.props.routes) {
-      // The reason we wrap in a div is because we just need to have a root element.
-      this._mapMarkedRoutes(<div>{this.props.routes}</div>);
+      this._isPlainRoute(this.props.routes)
+        ? this._mapMarkedPlainRoutes(this.props.routes)
+        // The reason we wrap in a div is because we just need to have a root element.
+        : this._mapMarkedRoutes(<div>{this.props.routes}</div>);
     } else {
       this._mapMarkedRoutes(this);
     }
@@ -55,6 +59,21 @@ export default class Router extends ReactRouter {
     this.sessionChangeListener = this._setSessionState.bind(this);
 
     context.setRouter(this);
+  }
+
+  _isPlainRoute(routeData) {
+    return (routeData.component)
+      || (routeData.length && routeData[0] && routeData[0].component);
+  }
+
+  _mapMarkedPlainRoutes(routeData, index) {
+    if (routeData.length) {
+      return (<div>{routeData.map(this._mapMarkedPlainRoutes)}</div>);
+    }
+
+    return (
+      <Route key={index} {...routeData} />
+    );
   }
 
   _mapMarkedRoutes(routes) {


### PR DESCRIPTION
Adds support for using [PlainRoute](https://github.com/ReactTraining/react-router/blob/master/docs/API.md#plainroute) format for specifying routes. This would also appear to allow integration with things like [react-boilerplate](https://github.com/react-boilerplate/react-boilerplate).

I _believe_ this:
Fixes #158 
Fixes #106 
Fixes #170 

Will check with authors of those issues.

@typerandom The router wrapper is your brainchild, can you check out the changes? Tested to work with the boilerplate and with the example project, but you never know :) 