### PR TITLE
Add ability to reset forms to initial state

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -259,6 +259,7 @@ Customize the form by providing your own markup.
   </p>
   <p>
     <input type="submit" value="Login" />
+    <button type="button" spResetErrors>Reset</button>
   </p>
 </LoginForm>
 ```
@@ -349,7 +350,7 @@ Specify `hideSocial` to hide the ability to register with a social provider.
 <RegistrationForm hideSocial={true} />
 ```
 
-Customize the form by providing your own markup. 
+Customize the form by providing your own markup.
 
 By default, the registration form will render these four fields, and they will be required by the user: `givenName`, `surname`, `email`, and `password`. Express.js users who want to make `givenName` and/or `surname` optional, or to add new required fields (like `username`), can refer to [Stormpath Express Library Guide](https://docs.stormpath.com/nodejs/express/latest/registration.html).
 
@@ -381,6 +382,7 @@ By default, the registration form will render these four fields, and they will b
     </p>
     <p>
       <input type="submit" value="Register" />
+      <button type="button" spResetErrors>Reset</button>
     </p>
   </div>
 </RegistrationForm>
@@ -492,6 +494,7 @@ Customize the form by providing your own markup.
     </p>
     <p>
       <input type="submit" value="Request Password reset" />
+      <button type="button" spResetErrors>Reset</button>
     </p>
   </div>
 </ResetPasswordForm>
@@ -556,6 +559,7 @@ Customize the form by providing your own markup.
     </p>
     <p>
       <input type="submit" value="Change Password" />
+      <button type="button" spResetErrors>Reset</button>
     </p>
   </div>
 </ChangePasswordForm>
@@ -669,6 +673,7 @@ Customize the form by providing your own markup.
   </p>
   <p>
     <input type="submit" value="Update" />
+    <button type="button" spResetErrors>Reset</button>
   </p>
 </UserProfileForm>
 ```

--- a/src/components/LoginForm.js
+++ b/src/components/LoginForm.js
@@ -297,19 +297,24 @@ export default class LoginForm extends React.Component {
     return result;
   }
 
+  _spResetErrorsHandler(element) {
+    return React.createElement(
+      element.type,
+      {
+        ...utils.excludeProps(['spResetErrors'], element.props),
+        onClick: this.reset.bind(this)
+      },
+      element.props.children
+    );
+  }
+
   render() {
     if (this.props.children) {
-      let selectedProps = utils.excludeProps(
-        ['redirectTo', 'hideSocial', 'onSubmit', 'onSubmitError', 'onSubmitSuccess', 'children'],
-        {
-          ...this.props,
-          reset: this.reset.bind(this),
-        }
-      );
+      let selectedProps = utils.excludeProps(['redirectTo', 'hideSocial', 'onSubmit', 'onSubmitError', 'onSubmitSuccess', 'children'], this.props);
 
       return (
         <form onSubmit={this.onFormSubmit.bind(this)} {...selectedProps}>
-          {utils.makeForm(this, this._mapFormFieldHandler.bind(this), this._spIfHandler.bind(this), this._spBindHandler.bind(this))}
+          {utils.makeForm(this, this._mapFormFieldHandler.bind(this), this._spIfHandler.bind(this), this._spBindHandler.bind(this), this._spResetErrorsHandler.bind(this))}
         </form>
       );
     } else {

--- a/src/components/LoginForm.js
+++ b/src/components/LoginForm.js
@@ -132,7 +132,6 @@ class DefaultLoginForm extends React.Component {
             <div className="col-xs-12">
               <div className="form-horizontal">
                 { fieldMarkup ? fieldMarkup : <LoadingText /> }
-                <div className="btn btn-primary" spResetErrors>Reset</div>
               </div>
             </div>
           </div>

--- a/src/components/LoginForm.js
+++ b/src/components/LoginForm.js
@@ -155,6 +155,16 @@ export default class LoginForm extends React.Component {
     isFormProcessing: false
   };
 
+  reset() {
+    this.setState({
+      fields: {
+        username: '',
+        password: '',
+      },
+      errorMessage: null,
+    });
+  }
+
   onFormSubmit(e) {
     e.preventDefault();
     e.persist();
@@ -289,7 +299,13 @@ export default class LoginForm extends React.Component {
 
   render() {
     if (this.props.children) {
-      let selectedProps = utils.excludeProps(['redirectTo', 'hideSocial', 'onSubmit', 'onSubmitError', 'onSubmitSuccess', 'children'], this.props);
+      let selectedProps = utils.excludeProps(
+        ['redirectTo', 'hideSocial', 'onSubmit', 'onSubmitError', 'onSubmitSuccess', 'children'],
+        {
+          ...this.props,
+          reset: this.reset.bind(this),
+        }
+      );
 
       return (
         <form onSubmit={this.onFormSubmit.bind(this)} {...selectedProps}>

--- a/src/components/LoginForm.js
+++ b/src/components/LoginForm.js
@@ -132,6 +132,7 @@ class DefaultLoginForm extends React.Component {
             <div className="col-xs-12">
               <div className="form-horizontal">
                 { fieldMarkup ? fieldMarkup : <LoadingText /> }
+                <div className="btn btn-primary" spResetErrors>Reset</div>
               </div>
             </div>
           </div>
@@ -155,7 +156,7 @@ export default class LoginForm extends React.Component {
     isFormProcessing: false
   };
 
-  reset() {
+  _reset() {
     this.setState({
       fields: {
         username: '',
@@ -297,24 +298,13 @@ export default class LoginForm extends React.Component {
     return result;
   }
 
-  _spResetErrorsHandler(element) {
-    return React.createElement(
-      element.type,
-      {
-        ...utils.excludeProps(['spResetErrors'], element.props),
-        onClick: this.reset.bind(this)
-      },
-      element.props.children
-    );
-  }
-
   render() {
     if (this.props.children) {
       let selectedProps = utils.excludeProps(['redirectTo', 'hideSocial', 'onSubmit', 'onSubmitError', 'onSubmitSuccess', 'children'], this.props);
 
       return (
         <form onSubmit={this.onFormSubmit.bind(this)} {...selectedProps}>
-          {utils.makeForm(this, this._mapFormFieldHandler.bind(this), this._spIfHandler.bind(this), this._spBindHandler.bind(this), this._spResetErrorsHandler.bind(this))}
+          {utils.makeForm(this, this._mapFormFieldHandler.bind(this), this._spIfHandler.bind(this), this._spBindHandler.bind(this), this._reset.bind(this))}
         </form>
       );
     } else {

--- a/src/components/RegistrationForm.js
+++ b/src/components/RegistrationForm.js
@@ -187,7 +187,7 @@ export default class RegistrationForm extends React.Component {
     isAccountEnabled: false
   };
 
-  reset() {
+  _reset() {
     this.setState({
       fields: {
         givenName: '',
@@ -386,24 +386,13 @@ export default class RegistrationForm extends React.Component {
     return result;
   }
 
-  _spResetErrorsHandler(element) {
-    return React.createElement(
-      element.type,
-      {
-        ...utils.excludeProps(['spResetErrors'], element.props),
-        onClick: this.reset.bind(this)
-      },
-      element.props.children
-    );
-  }
-
   render() {
     if (this.props.children) {
       var selectedProps = utils.excludeProps(['redirectTo', 'hideSocial', 'onSubmit', 'onSubmitError', 'onSubmitSuccess', 'children'], this.props);
 
       return (
         <form onSubmit={this.onFormSubmit.bind(this)} {...selectedProps}>
-          {utils.makeForm(this, this._mapFormFieldHandler.bind(this), this._spIfHandler.bind(this), this._spBindHandler.bind(this), this._spResetErrorsHandler.bind(this))}
+          {utils.makeForm(this, this._mapFormFieldHandler.bind(this), this._spIfHandler.bind(this), this._spBindHandler.bind(this), this._reset.bind(this))}
         </form>
       );
     } else {

--- a/src/components/RegistrationForm.js
+++ b/src/components/RegistrationForm.js
@@ -386,18 +386,24 @@ export default class RegistrationForm extends React.Component {
     return result;
   }
 
+  _spResetErrorsHandler(element) {
+    return React.createElement(
+      element.type,
+      {
+        ...utils.excludeProps(['spResetErrors'], element.props),
+        onClick: this.reset.bind(this)
+      },
+      element.props.children
+    );
+  }
+
   render() {
     if (this.props.children) {
-      var selectedProps = utils.excludeProps(
-        ['redirectTo', 'hideSocial', 'onSubmit', 'onSubmitError', 'onSubmitSuccess', 'children'],
-        {
-          ...this.props,
-          reset: this.reset.bind(this),
-        });
+      var selectedProps = utils.excludeProps(['redirectTo', 'hideSocial', 'onSubmit', 'onSubmitError', 'onSubmitSuccess', 'children'], this.props);
 
       return (
         <form onSubmit={this.onFormSubmit.bind(this)} {...selectedProps}>
-          {utils.makeForm(this, this._mapFormFieldHandler.bind(this), this._spIfHandler.bind(this), this._spBindHandler.bind(this))}
+          {utils.makeForm(this, this._mapFormFieldHandler.bind(this), this._spIfHandler.bind(this), this._spBindHandler.bind(this), this._spResetErrorsHandler.bind(this))}
         </form>
       );
     } else {

--- a/src/components/RegistrationForm.js
+++ b/src/components/RegistrationForm.js
@@ -187,6 +187,18 @@ export default class RegistrationForm extends React.Component {
     isAccountEnabled: false
   };
 
+  reset() {
+    this.setState({
+      fields: {
+        givenName: '',
+        surname: '',
+        email: '',
+        password: ''
+      },
+      errorMessage: null,
+    });
+  }
+
   onFormSubmit(e) {
     e.preventDefault();
     e.persist();
@@ -376,7 +388,12 @@ export default class RegistrationForm extends React.Component {
 
   render() {
     if (this.props.children) {
-      var selectedProps = utils.excludeProps(['redirectTo', 'hideSocial', 'onSubmit', 'onSubmitError', 'onSubmitSuccess', 'children'], this.props);
+      var selectedProps = utils.excludeProps(
+        ['redirectTo', 'hideSocial', 'onSubmit', 'onSubmitError', 'onSubmitSuccess', 'children'],
+        {
+          ...this.props,
+          reset: this.reset.bind(this),
+        });
 
       return (
         <form onSubmit={this.onFormSubmit.bind(this)} {...selectedProps}>

--- a/src/components/ResetPasswordForm.js
+++ b/src/components/ResetPasswordForm.js
@@ -53,7 +53,7 @@ export default class ResetPasswordForm extends React.Component {
     isFormSent: false
   };
 
-  reset() {
+  _reset() {
     this.setState({
       fields: {
         email: '',
@@ -157,24 +157,13 @@ export default class ResetPasswordForm extends React.Component {
     return result;
   }
 
-  _spResetErrorsHandler(element) {
-    return React.createElement(
-      element.type,
-      {
-        ...utils.excludeProps(['spResetErrors'], element.props),
-        onClick: this.reset.bind(this)
-      },
-      element.props.children
-    );
-  }
-
   render() {
     if (this.props.children) {
       var selectedProps = utils.excludeProps(['onSubmit', 'children'], this.props);
 
       return (
         <form onSubmit={this.onFormSubmit.bind(this)} {...selectedProps}>
-          {utils.makeForm(this, this._mapFormFieldHandler.bind(this), this._spIfHandler.bind(this), this._spBindHandler.bind(this), this._spResetErrorsHandler.bind(this))}
+          {utils.makeForm(this, this._mapFormFieldHandler.bind(this), this._spIfHandler.bind(this), this._spBindHandler.bind(this), this._reset.bind(this))}
         </form>
       );
     } else {

--- a/src/components/ResetPasswordForm.js
+++ b/src/components/ResetPasswordForm.js
@@ -53,6 +53,15 @@ export default class ResetPasswordForm extends React.Component {
     isFormSent: false
   };
 
+  reset() {
+    this.setState({
+      fields: {
+        email: '',
+      },
+      errorMessage: null,
+    });
+  }
+
   onFormSubmit(e) {
     e.preventDefault();
     e.persist();
@@ -150,7 +159,10 @@ export default class ResetPasswordForm extends React.Component {
 
   render() {
     if (this.props.children) {
-      var selectedProps = utils.excludeProps(['onSubmit', 'children'], this.props);
+      var selectedProps = utils.excludeProps(['onSubmit', 'children'], {
+        ...this.props,
+        reset: this.reset.bind(this)
+      });
 
       return (
         <form onSubmit={this.onFormSubmit.bind(this)} {...selectedProps}>

--- a/src/components/ResetPasswordForm.js
+++ b/src/components/ResetPasswordForm.js
@@ -157,16 +157,24 @@ export default class ResetPasswordForm extends React.Component {
     return result;
   }
 
+  _spResetErrorsHandler(element) {
+    return React.createElement(
+      element.type,
+      {
+        ...utils.excludeProps(['spResetErrors'], element.props),
+        onClick: this.reset.bind(this)
+      },
+      element.props.children
+    );
+  }
+
   render() {
     if (this.props.children) {
-      var selectedProps = utils.excludeProps(['onSubmit', 'children'], {
-        ...this.props,
-        reset: this.reset.bind(this)
-      });
+      var selectedProps = utils.excludeProps(['onSubmit', 'children'], this.props);
 
       return (
         <form onSubmit={this.onFormSubmit.bind(this)} {...selectedProps}>
-          {utils.makeForm(this, this._mapFormFieldHandler.bind(this), this._spIfHandler.bind(this), this._spBindHandler.bind(this))}
+          {utils.makeForm(this, this._mapFormFieldHandler.bind(this), this._spIfHandler.bind(this), this._spBindHandler.bind(this), this._spResetErrorsHandler.bind(this))}
         </form>
       );
     } else {

--- a/src/components/UserProfileForm.js
+++ b/src/components/UserProfileForm.js
@@ -91,7 +91,7 @@ export default class UserProfileForm extends React.Component {
     isFormSuccessful: false
   };
 
-  reset() {
+  _reset() {
     this.setState({
       fields: {},
       errorMessage: null,
@@ -219,24 +219,13 @@ export default class UserProfileForm extends React.Component {
     return result;
   }
 
-  _spResetErrorsHandler(element) {
-    return React.createElement(
-      element.type,
-      {
-        ...utils.excludeProps(['spResetErrors'], element.props),
-        onClick: this.reset.bind(this)
-      },
-      element.props.children
-    );
-  }
-
   render() {
     if (this.props.children) {
       let selectedProps = utils.excludeProps(['onSubmit', 'children'], this.props);
 
       return (
         <form onSubmit={this._onFormSubmit.bind(this)} {...selectedProps}>
-          {utils.makeForm(this, this._mapFormFieldHandler.bind(this), this._spIfHandler.bind(this), this._spBindHandler.bind(this), this._spResetErrorsHandler.bind(this))}
+          {utils.makeForm(this, this._mapFormFieldHandler.bind(this), this._spIfHandler.bind(this), this._spBindHandler.bind(this), this._reset.bind(this))}
         </form>
       );
     } else {

--- a/src/components/UserProfileForm.js
+++ b/src/components/UserProfileForm.js
@@ -91,6 +91,13 @@ export default class UserProfileForm extends React.Component {
     isFormSuccessful: false
   };
 
+  reset() {
+    this.setState({
+      fields: {},
+      errorMessage: null,
+    });
+  }
+
   _updateSessionData = (data, callback) => {
     var sessionStore = context.sessionStore;
 
@@ -214,7 +221,10 @@ export default class UserProfileForm extends React.Component {
 
   render() {
     if (this.props.children) {
-      let selectedProps = utils.excludeProps(['onSubmit', 'children'], this.props);
+      let selectedProps = utils.excludeProps(['onSubmit', 'children'], {
+        ...this.props,
+        reset: this.reset.bind(this),
+      });
 
       return (
         <form onSubmit={this._onFormSubmit.bind(this)} {...selectedProps}>

--- a/src/components/UserProfileForm.js
+++ b/src/components/UserProfileForm.js
@@ -219,16 +219,24 @@ export default class UserProfileForm extends React.Component {
     return result;
   }
 
+  _spResetErrorsHandler(element) {
+    return React.createElement(
+      element.type,
+      {
+        ...utils.excludeProps(['spResetErrors'], element.props),
+        onClick: this.reset.bind(this)
+      },
+      element.props.children
+    );
+  }
+
   render() {
     if (this.props.children) {
-      let selectedProps = utils.excludeProps(['onSubmit', 'children'], {
-        ...this.props,
-        reset: this.reset.bind(this),
-      });
+      let selectedProps = utils.excludeProps(['onSubmit', 'children'], this.props);
 
       return (
         <form onSubmit={this._onFormSubmit.bind(this)} {...selectedProps}>
-          {utils.makeForm(this, this._mapFormFieldHandler.bind(this), this._spIfHandler.bind(this), this._spBindHandler.bind(this))}
+          {utils.makeForm(this, this._mapFormFieldHandler.bind(this), this._spIfHandler.bind(this), this._spBindHandler.bind(this), this._spResetErrorsHandler.bind(this))}
         </form>
       );
     } else {

--- a/src/utils.js
+++ b/src/utils.js
@@ -264,10 +264,24 @@ class Utils {
           var spResetErrors = this.takeProp(element.props, 'spResetErrors', 'data-spResetErrors');
 
           if (spResetErrors) {
-            var newElement = spResetErrorsFn(element);
-            if (newElement !== false || newElement) {
-              element = newElement;
-            }
+            const oldHandler = element.props.onClick
+              ? element.props.onClick
+              : null;
+
+            element = React.createElement(
+              element.type,
+              {
+                ...this.excludeProps(['spResetErrors', 'data-spResetErrors'], element.props),
+                onClick(...args) {
+                  spResetErrorsFn(...args);
+
+                  if (oldHandler) {
+                    oldHandler(...args);
+                  }
+                }
+              },
+              element.props.children
+            );
           }
         }
       }

--- a/src/utils.js
+++ b/src/utils.js
@@ -215,7 +215,7 @@ class Utils {
     }
   }
 
-  makeForm(source, fieldMapFn, spIfFn, spBindFn) {
+  makeForm(source, fieldMapFn, spIfFn, spBindFn, spResetErrorsFn) {
     var root = React.cloneElement(<div />, {}, source.props.children);
     var fieldMap = this.getFormFieldMap(root, fieldMapFn);
 
@@ -257,6 +257,17 @@ class Utils {
           var newElement = spBindFn(spBind, element);
           if (newElement !== false || newElement) {
             element = newElement;
+          }
+        }
+
+        if (spResetErrorsFn) {
+          var spResetErrors = this.takeProp(element.props, 'spResetErrors', 'data-spResetErrors');
+
+          if (spResetErrors) {
+            var newElement = spResetErrorsFn(element);
+            if (newElement !== false || newElement) {
+              element = newElement;
+            }
           }
         }
       }


### PR DESCRIPTION
Add `spResetErrors`/`data-spResetErrors`, which will reset the error state and set the initial `state.fields` values.

Document changes.

Fixes #183