### PR TITLE
Make auto-login opt-in behaviour in RegistrationForm

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -349,7 +349,19 @@ Specify `hideSocial` to hide the ability to register with a social provider.
 <RegistrationForm hideSocial={true} />
 ```
 
-Customize the form by providing your own markup. 
+Specify `autoLogin` to automatically login the user after registration.
+
+```html
+<RegistrationForm autoLogin={true} />
+```
+
+or just
+
+```html
+<RegistrationForm autoLogin />
+```
+
+Customize the form by providing your own markup.
 
 By default, the registration form will render these four fields, and they will be required by the user: `givenName`, `surname`, `email`, and `password`. Express.js users who want to make `givenName` and/or `surname` optional, or to add new required fields (like `username`), can refer to [Stormpath Express Library Guide](https://docs.stormpath.com/nodejs/express/latest/registration.html).
 

--- a/src/components/RegistrationForm.js
+++ b/src/components/RegistrationForm.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {PropTypes} from 'react';
 import { Link } from 'react-router';
 
 import utils from '../utils';
@@ -174,6 +174,17 @@ export default class RegistrationForm extends React.Component {
     router: React.PropTypes.object.isRequired
   };
 
+  static propTypes = {
+    autoLogin: PropTypes.bool,
+    onSubmitSuccess: PropTypes.func,
+    onSubmitError: PropTypes.func,
+    onSubmit: PropTypes.func,
+  };
+
+  static defaultProps = {
+    autoLogin: false
+  };
+
   state = {
     fields: {
       givenName: '',
@@ -230,7 +241,7 @@ export default class RegistrationForm extends React.Component {
           }
 
           setErrorState(err);
-        } else if (result.status === 'ENABLED') {
+        } else if (result.status === 'ENABLED' && this.props.autoLogin) {
           UserActions.login({
             login: data.email || data.username,
             password: data.password
@@ -376,7 +387,7 @@ export default class RegistrationForm extends React.Component {
 
   render() {
     if (this.props.children) {
-      var selectedProps = utils.excludeProps(['redirectTo', 'hideSocial', 'onSubmit', 'onSubmitError', 'onSubmitSuccess', 'children'], this.props);
+      var selectedProps = utils.excludeProps(['autoLogin', 'redirectTo', 'hideSocial', 'onSubmit', 'onSubmitError', 'onSubmitSuccess', 'children'], this.props);
 
       return (
         <form onSubmit={this.onFormSubmit.bind(this)} {...selectedProps}>


### PR DESCRIPTION
Add `autoLogin` property to `<RegistrationForm>`. With it set, the old behaviour occurs - the user is registered, then logged in automatically. If not set, the second step does not happen.

Fixes #116 