### PR TITLE
Fix inGroups prop resolution

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -457,8 +457,19 @@ class Utils {
       return false;
     }
 
-    var scope = JSON.parse(JSON.stringify(groups));
-    var expressionFn = this.makePredicateFunction(expression);
+    if (!Array.isArray(groups) && typeof groups.items !== 'undefined') {
+      groups = groups.items.map((group) => group.name);
+    }
+
+    const scope = JSON.parse(JSON.stringify(groups));
+    let expressionFn;
+
+    try {
+      expressionFn = this.makePredicateFunction(expression);
+    } catch(err) {
+      this.logWarning('GroupExpression', `Invalid boolean group expression: "${expression}"`);
+      return false;
+    }
 
     expression.match(/(\w+)/gmi).forEach((wordMatch) => {
       if (!(wordMatch in scope)) {


### PR DESCRIPTION
Fix an issue where the group membership resolver expected the groups to be an array of strings, and it was instead an array of objects. If any integration actually provides an array of strings, it will be backwards-compatible.

Fixes #188 